### PR TITLE
Add a permanent no-cache live production contract

### DIFF
--- a/.github/workflows/live-contract.yml
+++ b/.github/workflows/live-contract.yml
@@ -1,0 +1,37 @@
+name: Live Production Contract
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-production-contract
+  cancel-in-progress: false
+
+jobs:
+  verify-live:
+    name: No-cache HTTP and representation contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Verify deployed Cloudflare contract
+        env:
+          LIVE_VERIFY_ATTEMPTS: 20
+          LIVE_VERIFY_DELAY_MS: 15000
+        run: node scripts/verify-live.mjs

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview",
     "check": "ASTRO_TELEMETRY_DISABLED=1 astro check --minimumFailingSeverity warning",
     "test": "node --test tests/*.test.mjs",
-    "validate": "npm run check && npm run test && npm run build"
+    "validate": "npm run check && npm run test && npm run build",
+    "verify:live": "node scripts/verify-live.mjs"
   },
   "devDependencies": {
     "@astrojs/check": "0.9.10",

--- a/scripts/verify-live.mjs
+++ b/scripts/verify-live.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+
+const ORIGIN = process.env.LIVE_ORIGIN ?? 'https://www.ghezelbaash.ir';
+const ATTEMPTS = Number.parseInt(process.env.LIVE_VERIFY_ATTEMPTS ?? '20', 10);
+const DELAY_MS = Number.parseInt(process.env.LIVE_VERIFY_DELAY_MS ?? '15000', 10);
+const CONTENT_SIGNAL = 'search=yes, ai-input=yes, ai-train=yes, use=reference';
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function cacheBustedURL(pathname) {
+  const url = new URL(pathname, ORIGIN);
+  url.searchParams.set('__live_verify', `${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  return url;
+}
+
+async function request(pathname, { accept, redirect = 'manual' } = {}) {
+  const headers = new Headers({
+    'Cache-Control': 'no-cache',
+    Pragma: 'no-cache',
+    'User-Agent': 'doctor-ghezelbaash-live-contract/1.0',
+  });
+  if (accept) headers.set('Accept', accept);
+
+  const response = await fetch(cacheBustedURL(pathname), {
+    headers,
+    redirect,
+  });
+  const body = await response.text();
+  return { response, body };
+}
+
+function header(response, name) {
+  return response.headers.get(name) ?? '';
+}
+
+function assertContainsHeaderToken(response, name, token) {
+  const values = header(response, name)
+    .split(',')
+    .map((value) => value.trim().toLowerCase());
+  assert.ok(values.includes(token.toLowerCase()), `${name} must include ${token}; received ${header(response, name)}`);
+}
+
+async function verifyCanonicalHTML() {
+  const { response, body } = await request('/', {
+    accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  });
+
+  assert.equal(response.status, 200, `canonical HTML returned ${response.status}`);
+  assert.match(header(response, 'content-type'), /^text\/html\b/i);
+  assert.match(header(response, 'cache-control'), /(?:^|,)\s*max-age=300(?:,|$)/i);
+  assertContainsHeaderToken(response, 'vary', 'Accept');
+  assert.equal(header(response, 'content-signal'), CONTENT_SIGNAL);
+  assert.match(body, /<html\b[^>]*\blang=["']fa-IR["']/i);
+  assert.match(body, /<link\b[^>]*\brel=["']canonical["'][^>]*\bhref=["']https:\/\/www\.ghezelbaash\.ir\/?["']/i);
+
+  const preloadTags = body.match(/<link\b[^>]*\brel=["']preload["'][^>]*>/gi) ?? [];
+  const fontPreload = preloadTags.find((tag) => tag.includes('/fonts/vazirmatn-nl-wght.woff2')) ?? '';
+  assert.ok(fontPreload, 'desktop Vazirmatn preload is missing from live HTML');
+  assert.match(fontPreload, /\bas=["']font["']/i);
+  assert.match(fontPreload, /\btype=["']font\/woff2["']/i);
+  assert.match(fontPreload, /\bmedia=["']\(min-width:\s*48\.001rem\)["']/i);
+
+  const stylesheetURLs = [...body.matchAll(/<link\b[^>]*\brel=["']stylesheet["'][^>]*\bhref=["']([^"']+)["'][^>]*>/gi)]
+    .map((match) => new URL(match[1], ORIGIN));
+  assert.ok(stylesheetURLs.length > 0, 'live HTML exposes no stylesheet links');
+
+  const stylesheets = await Promise.all(
+    stylesheetURLs.map(async (url) => {
+      url.searchParams.set('__live_verify', `${Date.now()}-${Math.random().toString(16).slice(2)}`);
+      const response = await fetch(url, {
+        headers: { 'Cache-Control': 'no-cache', Pragma: 'no-cache' },
+      });
+      assert.equal(response.status, 200, `stylesheet ${url.pathname} returned ${response.status}`);
+      return response.text();
+    }),
+  );
+  const css = stylesheets.join('\n');
+  assert.match(css, /:has\(main\s+:target\)/i, 'target-aware fragment materialization rule is missing');
+  assert.match(css, /content-visibility:\s*visible/i, 'fragment materialization does not force visible geometry');
+  assert.match(css, /contain-intrinsic-size:\s*none/i, 'fragment materialization does not clear intrinsic placeholders');
+}
+
+async function verifyMarkdownNegotiation() {
+  const { response, body } = await request('/', {
+    accept: 'text/markdown, text/html;q=0.2',
+  });
+
+  assert.equal(response.status, 200, `Markdown representation returned ${response.status}`);
+  assert.match(header(response, 'content-type'), /^text\/markdown\b/i);
+  assert.equal(header(response, 'content-location'), '/index.md');
+  assert.equal(header(response, 'content-language'), 'fa-IR');
+  assert.match(header(response, 'x-robots-tag'), /\bnoindex\b/i);
+  assertContainsHeaderToken(response, 'vary', 'Accept');
+  assert.equal(header(response, 'content-signal'), CONTENT_SIGNAL);
+  assert.match(body, /^---\n[\s\S]*?\n---\n/m, 'Markdown projection is missing canonical frontmatter');
+  assert.match(body, /canonical:\s*["']https:\/\/www\.ghezelbaash\.ir\/?["']/i);
+}
+
+async function verifyRobotsPolicy() {
+  const { response, body } = await request('/robots.txt', { accept: 'text/plain,*/*;q=0.1' });
+
+  assert.equal(response.status, 200, `robots.txt returned ${response.status}`);
+  assert.match(header(response, 'content-type'), /^text\/plain\b/i);
+  assert.match(body, /^User-agent:\s*OAI-SearchBot$/m);
+  assert.match(body, /^User-agent:\s*Claude-SearchBot$/m);
+  assert.match(body, /^User-agent:\s*PerplexityBot$/m);
+  assert.match(body, new RegExp(`^Content-Signal:\\s*${CONTENT_SIGNAL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'));
+  assert.match(body, /^Sitemap:\s*https:\/\/www\.ghezelbaash\.ir\/sitemap\.xml$/m);
+}
+
+async function verify404Aliases() {
+  for (const pathname of ['/404', '/404/', '/404.html']) {
+    const { response, body } = await request(pathname, { accept: 'text/html,*/*;q=0.1' });
+
+    assert.equal(response.status, 404, `${pathname} returned ${response.status} instead of 404`);
+    assert.match(header(response, 'content-type'), /^text\/html\b/i);
+    assert.equal(header(response, 'cache-control'), 'no-store');
+    assert.match(header(response, 'x-robots-tag'), /\bnoindex\b/i);
+    assert.equal(header(response, 'content-location'), '/404.html');
+    assert.equal(header(response, 'content-signal'), CONTENT_SIGNAL);
+    assert.match(body, /<meta\b[^>]*\bname=["']robots["'][^>]*\bcontent=["'][^"']*noindex/i);
+    assert.match(body, />404</);
+  }
+}
+
+async function verifyLiveContract() {
+  await verifyRobotsPolicy();
+  await verifyCanonicalHTML();
+  await verifyMarkdownNegotiation();
+  await verify404Aliases();
+}
+
+let lastError;
+for (let attempt = 1; attempt <= ATTEMPTS; attempt += 1) {
+  try {
+    await verifyLiveContract();
+    console.log(`Live contract verified against ${ORIGIN} on attempt ${attempt}/${ATTEMPTS}.`);
+    process.exit(0);
+  } catch (error) {
+    lastError = error;
+    console.error(`Live verification attempt ${attempt}/${ATTEMPTS} failed: ${error.message}`);
+    if (attempt < ATTEMPTS) await sleep(DELAY_MS);
+  }
+}
+
+throw lastError;


### PR DESCRIPTION
## هدف

این PR مرحلهٔ «تأیید لایو پس از استقرار» را از یک بررسی دستی و غیرقابل‌تکرار به یک قرارداد دائمی CI تبدیل می‌کند.

## پوشش آزمون زنده

- HTML canonical با درخواست no-cache، status 200، `Vary: Accept`، Content-Signal و cache پنج‌دقیقه‌ای.
- preload مشروط Vazirmatn در HTML واقعی.
- حضور rule نهایی fragment navigation در CSS منتشرشده.
- negotiation واقعی Markdown با `Accept: text/markdown`، frontmatter، Content-Location و noindex.
- robots.txt شامل crawlerهای رسمی و Content-Signal کامل.
- status واقعی 404، no-store و noindex برای `/404`، `/404/` و `/404.html`.
- retry کنترل‌شده برای عبور از فاصلهٔ زمانی میان merge و deployment Cloudflare.

## معماری

- `scripts/verify-live.mjs`: verifier مستقل مبتنی بر Node 24 و Fetch API.
- `.github/workflows/live-contract.yml`: اجرا روی PR، push به main و اجرای دستی.
- `npm run verify:live`: اجرای محلی یا CI یکسان.

## نتیجهٔ نهایی

- Quality Gate: **success**.
- Live Production Contract: **success**.
- production واقعی با درخواست‌های cache-busted و `Cache-Control: no-cache` در **تلاش اول از ۲۰ تلاش** تمام قراردادها را پاس کرد.

این کنترل هیچ تغییری در محتوای canonical یا سلسله‌مراتب انتیتی ایجاد نمی‌کند؛ فقط قرارداد تحویل واقعی production را enforce می‌کند.