### PR TITLE
Fix canonical physician-owned Dataset graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "npm@11.19.0",
   "scripts": {
-    "normalize:dataset": "node scripts/retire-duplicate-datasets.mjs && node scripts/normalize-dataset-entity.mjs",
+    "normalize:dataset": "node scripts/normalize-visible-dataset-copy.mjs && node scripts/retire-duplicate-datasets.mjs && node scripts/normalize-dataset-entity.mjs",
     "predev": "npm run normalize:dataset",
     "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
     "prebuild": "npm run normalize:dataset",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,15 @@
   "type": "module",
   "packageManager": "npm@11.19.0",
   "scripts": {
+    "normalize:dataset": "node scripts/normalize-dataset-entity.mjs",
+    "predev": "npm run normalize:dataset",
     "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
+    "prebuild": "npm run normalize:dataset",
     "build": "ASTRO_TELEMETRY_DISABLED=1 astro build",
     "preview": "ASTRO_TELEMETRY_DISABLED=1 astro preview",
+    "precheck": "npm run normalize:dataset",
     "check": "ASTRO_TELEMETRY_DISABLED=1 astro check --minimumFailingSeverity warning",
+    "pretest": "npm run normalize:dataset",
     "test": "node --test tests/*.test.mjs",
     "validate": "npm run check && npm run test && npm run build",
     "verify:live": "node scripts/verify-live.mjs"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "npm@11.19.0",
   "scripts": {
-    "normalize:dataset": "node scripts/normalize-dataset-entity.mjs",
+    "normalize:dataset": "node scripts/retire-duplicate-datasets.mjs && node scripts/normalize-dataset-entity.mjs",
     "predev": "npm run normalize:dataset",
     "dev": "ASTRO_TELEMETRY_DISABLED=1 astro dev",
     "prebuild": "npm run normalize:dataset",

--- a/scripts/normalize-dataset-entity.mjs
+++ b/scripts/normalize-dataset-entity.mjs
@@ -15,6 +15,7 @@ const PROJECT_ID = 'https://www.ghezelbaash.ir/#doctor-ghezelbaash-structured-da
 const CATALOG_ID = 'https://www.ghezelbaash.ir/#data-catalog';
 const PRIMARY_DATASET_ID = 'https://www.ghezelbaash.ir/graph.jsonld#dataset';
 const HISTORICAL_DATASET_ID = 'https://www.ghezelbaash.ir/#historical-patient-origin-summary';
+const REPUTATION_SNAPSHOT_ID = 'https://www.ghezelbaash.ir/#google-maps-reputation-snapshot-current';
 const LEGACY_HUGGINGFACE_DATASET_ID = 'https://www.ghezelbaash.ir/#project-huggingface-dataset';
 const JSONLD_DOWNLOAD_ID = 'https://www.ghezelbaash.ir/graph.jsonld#download';
 const TURTLE_DOWNLOAD_ID = 'https://www.ghezelbaash.ir/graph.ttl#download';
@@ -46,11 +47,8 @@ function replaceLegacyReference(value) {
 
   const output = {};
   for (const [key, child] of Object.entries(value)) {
-    if (key === '@id' && child === LEGACY_HUGGINGFACE_DATASET_ID) {
-      output[key] = PRIMARY_DATASET_ID;
-    } else {
-      output[key] = replaceLegacyReference(child);
-    }
+    if (key === '@id' && child === LEGACY_HUGGINGFACE_DATASET_ID) output[key] = PRIMARY_DATASET_ID;
+    else output[key] = replaceLegacyReference(child);
   }
   return output;
 }
@@ -59,6 +57,19 @@ function findRequiredNode(graph, id, label) {
   const node = graph.find((entry) => entry?.['@id'] === id);
   if (!node) throw new Error(`Missing ${label}: ${id}`);
   return node;
+}
+
+function normalizeOwnedSupportingDataset(node) {
+  if (!node) return;
+  node.creator = ref(PERSON_ID);
+  node.publisher = ref(PERSON_ID);
+  node.copyrightHolder = ref(PERSON_ID);
+  node.maintainer = ref(PERSON_ID);
+  node.accountablePerson = ref(PERSON_ID);
+  node.includedInDataCatalog = ref(CATALOG_ID);
+  node.isPartOf = ref(PRIMARY_DATASET_ID);
+  if (!Object.hasOwn(node, 'isAccessibleForFree')) node.isAccessibleForFree = true;
+  if (!node.license) node.license = 'https://creativecommons.org/licenses/by/4.0/';
 }
 
 function normalizeDocument(document, sourceLabel) {
@@ -73,12 +84,14 @@ function normalizeDocument(document, sourceLabel) {
   const graph = document['@graph'];
   const primary = findRequiredNode(graph, PRIMARY_DATASET_ID, 'primary Dataset');
   const historical = findRequiredNode(graph, HISTORICAL_DATASET_ID, 'historical Dataset');
+  const reputationSnapshot = graph.find((entry) => entry?.['@id'] === REPUTATION_SNAPSHOT_ID);
   const person = findRequiredNode(graph, PERSON_ID, 'physician Person');
   const clinic = findRequiredNode(graph, CLINIC_ID, 'physician-owned clinic');
   const project = findRequiredNode(graph, PROJECT_ID, 'structured-data repository');
   const catalog = findRequiredNode(graph, CATALOG_ID, 'DataCatalog');
   const jsonDownload = findRequiredNode(graph, JSONLD_DOWNLOAD_ID, 'JSON-LD distribution');
   const turtleDownload = findRequiredNode(graph, TURTLE_DOWNLOAD_ID, 'Turtle distribution');
+  const supportingDatasetIds = [HISTORICAL_DATASET_ID, ...(reputationSnapshot ? [REPUTATION_SNAPSHOT_ID] : [])];
 
   Object.assign(primary, {
     '@type': 'Dataset',
@@ -108,7 +121,7 @@ function normalizeDocument(document, sourceLabel) {
     license: 'https://creativecommons.org/licenses/by/4.0/',
     isAccessibleForFree: true,
     includedInDataCatalog: ref(CATALOG_ID),
-    hasPart: [ref(HISTORICAL_DATASET_ID)],
+    hasPart: supportingDatasetIds.map(ref),
     keywords: [
       'Saeed Ghezelbash',
       'Mohammad Saeed Ghezelbash',
@@ -126,11 +139,8 @@ function normalizeDocument(document, sourceLabel) {
   delete primary.isPartOf;
   delete primary.isBasedOn;
 
-  historical.creator = ref(PERSON_ID);
-  historical.publisher = ref(PERSON_ID);
-  historical.copyrightHolder = ref(PERSON_ID);
-  historical.includedInDataCatalog = ref(CATALOG_ID);
-  historical.isPartOf = ref(PRIMARY_DATASET_ID);
+  normalizeOwnedSupportingDataset(historical);
+  normalizeOwnedSupportingDataset(reputationSnapshot);
 
   Object.assign(project, {
     creator: ref(PERSON_ID),
@@ -141,10 +151,10 @@ function normalizeDocument(document, sourceLabel) {
     accountablePerson: ref(PERSON_ID),
     hasPart: unique([
       ref(PRIMARY_DATASET_ID),
-      ref(HISTORICAL_DATASET_ID),
+      ...supportingDatasetIds.map(ref),
       ref(CATALOG_ID),
       ...asArray(project.hasPart).filter(
-        (item) => ![PRIMARY_DATASET_ID, HISTORICAL_DATASET_ID, CATALOG_ID, LEGACY_HUGGINGFACE_DATASET_ID].includes(item?.['@id']),
+        (item) => ![PRIMARY_DATASET_ID, ...supportingDatasetIds, CATALOG_ID, LEGACY_HUGGINGFACE_DATASET_ID].includes(item?.['@id']),
       ),
     ]),
     dateModified: DATE_MODIFIED,
@@ -154,7 +164,7 @@ function normalizeDocument(document, sourceLabel) {
     creator: ref(PERSON_ID),
     publisher: ref(PERSON_ID),
     about: [ref(PERSON_ID), ref(CLINIC_ID)],
-    dataset: [ref(PRIMARY_DATASET_ID), ref(HISTORICAL_DATASET_ID)],
+    dataset: [ref(PRIMARY_DATASET_ID), ...supportingDatasetIds.map(ref)],
     dateModified: DATE_MODIFIED,
   });
 
@@ -179,6 +189,7 @@ function normalizeDocument(document, sourceLabel) {
   if (primaryNodes.length !== 1) {
     throw new Error(`${sourceLabel} must contain exactly one primary Dataset node; found ${primaryNodes.length}.`);
   }
+  console.log(`${sourceLabel}: Dataset inventory — ${datasetNodes.map((node) => node?.['@id']).filter(Boolean).join(', ')}`);
 
   return document;
 }
@@ -190,9 +201,7 @@ function expandIri(value, context, useVocab = false) {
     const prefix = value.slice(0, colon);
     const suffix = value.slice(colon + 1);
     const prefixValue = context?.[prefix];
-    if (typeof prefixValue === 'string' && /^[a-z][a-z0-9+.-]*:/i.test(prefixValue)) {
-      return `${prefixValue}${suffix}`;
-    }
+    if (typeof prefixValue === 'string' && /^[a-z][a-z0-9+.-]*:/i.test(prefixValue)) return `${prefixValue}${suffix}`;
     return value;
   }
   if (useVocab) {
@@ -205,9 +214,7 @@ function expandIri(value, context, useVocab = false) {
 function propertyIri(key, context) {
   const definition = context?.[key];
   if (typeof definition === 'string') return expandIri(definition, context, true);
-  if (definition && typeof definition === 'object' && typeof definition['@id'] === 'string') {
-    return expandIri(definition['@id'], context, true);
-  }
+  if (definition && typeof definition === 'object' && typeof definition['@id'] === 'string') return expandIri(definition['@id'], context, true);
   return expandIri(key, context, true);
 }
 
@@ -249,7 +256,7 @@ function jsonLdToTurtle(document) {
     }
     if (typeof value['@id'] === 'string') {
       const subject = iri(expandIri(value['@id'], context));
-      if (Object.keys(value).some((key) => !['@id'].includes(key))) emitNode(value, subject);
+      if (Object.keys(value).some((key) => key !== '@id')) emitNode(value, subject);
       return subject;
     }
 
@@ -295,22 +302,19 @@ function jsonLdToTurtle(document) {
 }
 
 async function readJson(filePath) {
-  const content = await readFile(filePath, 'utf8');
-  return JSON.parse(content);
+  return JSON.parse(await readFile(filePath, 'utf8'));
 }
 
 async function main() {
   const normalized = new Map();
   for (const filePath of JSON_GRAPH_PATHS) {
     const document = normalizeDocument(await readJson(filePath), path.relative(ROOT, filePath));
-    const serialized = `${JSON.stringify(document)}\n`;
-    await writeFile(filePath, serialized, 'utf8');
+    await writeFile(filePath, `${JSON.stringify(document)}\n`, 'utf8');
     normalized.set(filePath, document);
   }
 
   const publicDocument = normalized.get(path.join(ROOT, 'public/graph.jsonld'));
   await writeFile(TURTLE_PATH, jsonLdToTurtle(publicDocument), 'utf8');
-
   console.log('Canonical physician-owned Dataset normalized in embedded JSON-LD, public JSON-LD and Turtle.');
 }
 

--- a/scripts/normalize-dataset-entity.mjs
+++ b/scripts/normalize-dataset-entity.mjs
@@ -1,0 +1,317 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = process.cwd();
+const JSON_GRAPH_PATHS = [
+  path.join(ROOT, 'src/data/semantic/head-graph.min.jsonld'),
+  path.join(ROOT, 'public/graph.jsonld'),
+];
+const TURTLE_PATH = path.join(ROOT, 'public/graph.ttl');
+
+const PERSON_ID = 'https://www.ghezelbaash.ir/#saeed-ghezelbash';
+const CLINIC_ID = 'https://www.ghezelbaash.ir/#dr-saeed-ghezelbash-aesthetic-clinic-kermanshah';
+const PROJECT_ID = 'https://www.ghezelbaash.ir/#doctor-ghezelbaash-structured-data-project';
+const CATALOG_ID = 'https://www.ghezelbaash.ir/#data-catalog';
+const PRIMARY_DATASET_ID = 'https://www.ghezelbaash.ir/graph.jsonld#dataset';
+const HISTORICAL_DATASET_ID = 'https://www.ghezelbaash.ir/#historical-patient-origin-summary';
+const LEGACY_HUGGINGFACE_DATASET_ID = 'https://www.ghezelbaash.ir/#project-huggingface-dataset';
+const JSONLD_DOWNLOAD_ID = 'https://www.ghezelbaash.ir/graph.jsonld#download';
+const TURTLE_DOWNLOAD_ID = 'https://www.ghezelbaash.ir/graph.ttl#download';
+const HF_DATASET_URL = 'https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data';
+const ZENODO_DOI_URL = 'https://doi.org/10.5281/zenodo.18765169';
+const WIKIDATA_PROJECT_URL = 'https://www.wikidata.org/entity/Q140304972';
+const DATE_MODIFIED = '2026-08-04';
+
+const ref = (id) => ({ '@id': id });
+const asArray = (value) => (value == null ? [] : Array.isArray(value) ? value : [value]);
+const itemKey = (value) => {
+  if (value && typeof value === 'object' && typeof value['@id'] === 'string') return `@id:${value['@id']}`;
+  return JSON.stringify(value);
+};
+const unique = (values) => {
+  const seen = new Set();
+  return values.filter((value) => {
+    const key = itemKey(value);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};
+const ensureRef = (value, id) => unique([...asArray(value).filter((item) => item?.['@id'] !== LEGACY_HUGGINGFACE_DATASET_ID), ref(id)]);
+
+function replaceLegacyReference(value) {
+  if (Array.isArray(value)) return unique(value.map(replaceLegacyReference));
+  if (!value || typeof value !== 'object') return value;
+
+  const output = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === '@id' && child === LEGACY_HUGGINGFACE_DATASET_ID) {
+      output[key] = PRIMARY_DATASET_ID;
+    } else {
+      output[key] = replaceLegacyReference(child);
+    }
+  }
+  return output;
+}
+
+function findRequiredNode(graph, id, label) {
+  const node = graph.find((entry) => entry?.['@id'] === id);
+  if (!node) throw new Error(`Missing ${label}: ${id}`);
+  return node;
+}
+
+function normalizeDocument(document, sourceLabel) {
+  if (!document || typeof document !== 'object' || !Array.isArray(document['@graph'])) {
+    throw new Error(`${sourceLabel} is not a JSON-LD document with an @graph array.`);
+  }
+
+  document['@graph'] = document['@graph']
+    .filter((node) => node?.['@id'] !== LEGACY_HUGGINGFACE_DATASET_ID)
+    .map(replaceLegacyReference);
+
+  const graph = document['@graph'];
+  const primary = findRequiredNode(graph, PRIMARY_DATASET_ID, 'primary Dataset');
+  const historical = findRequiredNode(graph, HISTORICAL_DATASET_ID, 'historical Dataset');
+  const person = findRequiredNode(graph, PERSON_ID, 'physician Person');
+  const clinic = findRequiredNode(graph, CLINIC_ID, 'physician-owned clinic');
+  const project = findRequiredNode(graph, PROJECT_ID, 'structured-data repository');
+  const catalog = findRequiredNode(graph, CATALOG_ID, 'DataCatalog');
+  const jsonDownload = findRequiredNode(graph, JSONLD_DOWNLOAD_ID, 'JSON-LD distribution');
+  const turtleDownload = findRequiredNode(graph, TURTLE_DOWNLOAD_ID, 'Turtle distribution');
+
+  Object.assign(primary, {
+    '@type': 'Dataset',
+    name: 'Dr. Saeed Ghezelbash Entity Data',
+    alternateName: [
+      'Dr. Saeed Ghezelbaash Public Knowledge Graph',
+      'Doctor Ghezelbash Structured Data Repository',
+      'Primary physician entity Dataset',
+      'مجموعه‌داده اصلی انتیتی دکتر سعید قزلباش',
+    ],
+    description:
+      'Dr. Saeed Ghezelbash Entity Data is the single canonical public machine-readable Dataset created, published, owned, copyrighted and maintained by Saeed Ghezelbash. It represents the physician identified by Wikidata Q140287622 and Google Knowledge Graph /g/11nqdfk76c, covers his personally owned aesthetic clinic and structured-data repository, and is published through the official website, Hugging Face and Zenodo as synchronized authoritative distributions of the same Dataset.',
+    url: 'https://www.ghezelbaash.ir/#doctor-ghezelbaash-structured-data-repository',
+    creator: ref(PERSON_ID),
+    publisher: ref(PERSON_ID),
+    copyrightHolder: ref(PERSON_ID),
+    maintainer: ref(PERSON_ID),
+    accountablePerson: ref(PERSON_ID),
+    about: [ref(PERSON_ID), ref(CLINIC_ID), ref(PROJECT_ID)],
+    sameAs: [HF_DATASET_URL, ZENODO_DOI_URL, WIKIDATA_PROJECT_URL],
+    identifier: [
+      PRIMARY_DATASET_ID,
+      ref('https://www.ghezelbaash.ir/#identifier-project-doi'),
+      ref('https://www.ghezelbaash.ir/#identifier-project-wikidata'),
+    ],
+    distribution: [ref(JSONLD_DOWNLOAD_ID), ref(TURTLE_DOWNLOAD_ID)],
+    license: 'https://creativecommons.org/licenses/by/4.0/',
+    isAccessibleForFree: true,
+    includedInDataCatalog: ref(CATALOG_ID),
+    hasPart: [ref(HISTORICAL_DATASET_ID)],
+    keywords: [
+      'Saeed Ghezelbash',
+      'Mohammad Saeed Ghezelbash',
+      'physician entity data',
+      'physician knowledge graph',
+      'aesthetic medicine',
+      'Kermanshah',
+      'Wikidata Q140287622',
+      'Google Knowledge Graph /g/11nqdfk76c',
+      'linked data',
+    ],
+    version: '1.1.0',
+    dateModified: DATE_MODIFIED,
+  });
+  delete primary.isPartOf;
+  delete primary.isBasedOn;
+
+  historical.creator = ref(PERSON_ID);
+  historical.publisher = ref(PERSON_ID);
+  historical.copyrightHolder = ref(PERSON_ID);
+  historical.includedInDataCatalog = ref(CATALOG_ID);
+  historical.isPartOf = ref(PRIMARY_DATASET_ID);
+
+  Object.assign(project, {
+    creator: ref(PERSON_ID),
+    publisher: ref(PERSON_ID),
+    copyrightHolder: ref(PERSON_ID),
+    owner: ref(PERSON_ID),
+    maintainer: ref(PERSON_ID),
+    accountablePerson: ref(PERSON_ID),
+    hasPart: unique([
+      ref(PRIMARY_DATASET_ID),
+      ref(HISTORICAL_DATASET_ID),
+      ref(CATALOG_ID),
+      ...asArray(project.hasPart).filter(
+        (item) => ![PRIMARY_DATASET_ID, HISTORICAL_DATASET_ID, CATALOG_ID, LEGACY_HUGGINGFACE_DATASET_ID].includes(item?.['@id']),
+      ),
+    ]),
+    dateModified: DATE_MODIFIED,
+  });
+
+  Object.assign(catalog, {
+    creator: ref(PERSON_ID),
+    publisher: ref(PERSON_ID),
+    about: [ref(PERSON_ID), ref(CLINIC_ID)],
+    dataset: [ref(PRIMARY_DATASET_ID), ref(HISTORICAL_DATASET_ID)],
+    dateModified: DATE_MODIFIED,
+  });
+
+  person.subjectOf = ensureRef(person.subjectOf, PRIMARY_DATASET_ID);
+  clinic.subjectOf = ensureRef(clinic.subjectOf, PRIMARY_DATASET_ID);
+
+  for (const download of [jsonDownload, turtleDownload]) {
+    download.isPartOf = ref(PRIMARY_DATASET_ID);
+    download.license = 'https://creativecommons.org/licenses/by/4.0/';
+    download.isAccessibleForFree = true;
+    download.dateModified = DATE_MODIFIED;
+    download.version = '1.1.0';
+  }
+
+  const legacyText = JSON.stringify(document);
+  if (legacyText.includes(LEGACY_HUGGINGFACE_DATASET_ID)) {
+    throw new Error(`${sourceLabel} still contains the retired duplicate Dataset identifier.`);
+  }
+
+  const datasetNodes = graph.filter((node) => asArray(node?.['@type']).includes('Dataset'));
+  const primaryNodes = datasetNodes.filter((node) => node?.['@id'] === PRIMARY_DATASET_ID);
+  if (primaryNodes.length !== 1) {
+    throw new Error(`${sourceLabel} must contain exactly one primary Dataset node; found ${primaryNodes.length}.`);
+  }
+
+  return document;
+}
+
+function expandIri(value, context, useVocab = false) {
+  if (typeof value !== 'string') throw new TypeError(`IRI must be a string: ${String(value)}`);
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+    const colon = value.indexOf(':');
+    const prefix = value.slice(0, colon);
+    const suffix = value.slice(colon + 1);
+    const prefixValue = context?.[prefix];
+    if (typeof prefixValue === 'string' && /^[a-z][a-z0-9+.-]*:/i.test(prefixValue)) {
+      return `${prefixValue}${suffix}`;
+    }
+    return value;
+  }
+  if (useVocab) {
+    const vocab = context?.['@vocab'];
+    if (typeof vocab === 'string') return `${vocab}${value}`;
+  }
+  return value;
+}
+
+function propertyIri(key, context) {
+  const definition = context?.[key];
+  if (typeof definition === 'string') return expandIri(definition, context, true);
+  if (definition && typeof definition === 'object' && typeof definition['@id'] === 'string') {
+    return expandIri(definition['@id'], context, true);
+  }
+  return expandIri(key, context, true);
+}
+
+function propertyUsesIdValues(key, context) {
+  const definition = context?.[key];
+  return Boolean(definition && typeof definition === 'object' && definition['@type'] === '@id');
+}
+
+function iri(value) {
+  return `<${String(value).replace(/\\/g, '%5C').replace(/>/g, '%3E').replace(/</g, '%3C')}>`;
+}
+
+function literal(value, language, datatype) {
+  const text = JSON.stringify(String(value));
+  if (language) return `${text}@${language}`;
+  if (datatype) return `${text}^^${iri(datatype)}`;
+  return text;
+}
+
+function jsonLdToTurtle(document) {
+  const context = document['@context'] ?? {};
+  const triples = new Set();
+  const processedNamedNodes = new Set();
+  let blankCounter = 0;
+
+  const add = (subject, predicate, object) => triples.add(`${subject} ${predicate} ${object} .`);
+
+  const objectTerm = (value, propertyKey) => {
+    if (value == null) return null;
+    if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+    if (typeof value === 'string') {
+      if (propertyUsesIdValues(propertyKey, context)) return iri(expandIri(value, context));
+      return literal(value);
+    }
+    if (Array.isArray(value)) throw new TypeError('Arrays must be expanded by emitProperty.');
+    if (Object.hasOwn(value, '@value')) {
+      const datatype = value['@type'] ? expandIri(value['@type'], context) : undefined;
+      return literal(value['@value'], value['@language'], datatype);
+    }
+    if (typeof value['@id'] === 'string') {
+      const subject = iri(expandIri(value['@id'], context));
+      if (Object.keys(value).some((key) => !['@id'].includes(key))) emitNode(value, subject);
+      return subject;
+    }
+
+    const blank = `_:b${++blankCounter}`;
+    emitNode(value, blank);
+    return blank;
+  };
+
+  const emitProperty = (subject, key, value) => {
+    const predicate = iri(propertyIri(key, context));
+    for (const item of asArray(value)) {
+      const term = objectTerm(item, key);
+      if (term != null) add(subject, predicate, term);
+    }
+  };
+
+  const emitNode = (node, forcedSubject) => {
+    const namedId = typeof node['@id'] === 'string' ? expandIri(node['@id'], context) : null;
+    const subject = forcedSubject ?? (namedId ? iri(namedId) : `_:b${++blankCounter}`);
+    if (namedId) {
+      if (processedNamedNodes.has(namedId)) return subject;
+      processedNamedNodes.add(namedId);
+    }
+
+    for (const type of asArray(node['@type'])) {
+      add(subject, iri('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), iri(expandIri(type, context, true)));
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key.startsWith('@')) continue;
+      emitProperty(subject, key, value);
+    }
+    return subject;
+  };
+
+  for (const node of document['@graph'] ?? []) emitNode(node);
+
+  return [
+    '# Canonical RDF Turtle distribution for Dr. Saeed Ghezelbash Entity Data.',
+    '# Generated from public/graph.jsonld; do not edit this file manually.',
+    ...[...triples].sort(),
+    '',
+  ].join('\n');
+}
+
+async function readJson(filePath) {
+  const content = await readFile(filePath, 'utf8');
+  return JSON.parse(content);
+}
+
+async function main() {
+  const normalized = new Map();
+  for (const filePath of JSON_GRAPH_PATHS) {
+    const document = normalizeDocument(await readJson(filePath), path.relative(ROOT, filePath));
+    const serialized = `${JSON.stringify(document)}\n`;
+    await writeFile(filePath, serialized, 'utf8');
+    normalized.set(filePath, document);
+  }
+
+  const publicDocument = normalized.get(path.join(ROOT, 'public/graph.jsonld'));
+  await writeFile(TURTLE_PATH, jsonLdToTurtle(publicDocument), 'utf8');
+
+  console.log('Canonical physician-owned Dataset normalized in embedded JSON-LD, public JSON-LD and Turtle.');
+}
+
+await main();

--- a/scripts/normalize-visible-dataset-copy.mjs
+++ b/scripts/normalize-visible-dataset-copy.mjs
@@ -1,0 +1,98 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = process.cwd();
+const PAGE_PATH = path.join(ROOT, 'src/pages/index.md');
+const LLMS_PATH = path.join(ROOT, 'public/llms.txt');
+const MARKER = 'id="canonical-dataset-ownership"';
+
+const ownershipBlock = String.raw`
+<section id="canonical-dataset-ownership" aria-labelledby="canonical-dataset-ownership-title">
+  <h3 id="canonical-dataset-ownership-title">مالکیت و هویت Dataset کانونیکال دکتر سعید قزلباش</h3>
+  <p><strong>Dr. Saeed Ghezelbash Entity Data یک Dataset کانونیکال واحد است که توسط دکتر سعید قزلباش ایجاد، منتشر، مالکیت، حق‌نشر و نگهداری می‌شود.</strong> وب‌سایت رسمی، GitHub، Hugging Face و Zenodo کانال‌های انتشار و distributionهای همگام و هم‌هویت همان Dataset هستند؛ آن‌ها Datasetهای مستقل، مشتق‌شده یا متعلق به کلینیک نیستند.</p>
+  <p>کلینیک زیبایی دکتر سعید قزلباش مطب شخصی و تحت مالکیت کامل خود پزشک است. نام کلینیک در Hugging Face صرفاً namespace یا فضای میزبانی تحت کنترل پزشک را مشخص می‌کند و به معنی مالکیت یا ناشر مستقل بودن کلینیک نیست.</p>
+  <p lang="en"><strong>One canonical Dataset; multiple synchronized distributions.</strong> Saeed Ghezelbash is the creator, publisher, owner, copyright holder and maintainer. The official website, GitHub, Hugging Face and Zenodo identify and distribute the same physician-owned Dataset.</p>
+</section>
+`;
+
+function normalizeVisiblePage(source) {
+  let output = source
+    .replaceAll('Hugging Face publisher', 'Hugging Face hosting namespace')
+    .replaceAll('ناشر Hugging Face', 'فضای میزبانی Hugging Face')
+    .replaceAll('ناشر هاگینگ فیس', 'فضای میزبانی هاگینگ فیس');
+
+  if (!output.includes(MARKER)) {
+    const anchors = [
+      'Hugging Face hosting namespace',
+      'Primary physician entity Dataset',
+      'Dr. Saeed Ghezelbash Entity Data',
+      'Dr. Saeed Ghezelbaash Public Knowledge Graph',
+    ];
+    const located = anchors
+      .map((anchor) => ({ anchor, index: output.indexOf(anchor) }))
+      .filter(({ index }) => index >= 0)
+      .sort((a, b) => a.index - b.index)[0];
+
+    if (!located) {
+      throw new Error('Could not locate the visible structured-data section in src/pages/index.md.');
+    }
+
+    const lineStart = output.lastIndexOf('\n', located.index) + 1;
+    output = `${output.slice(0, lineStart)}${ownershipBlock}\n${output.slice(lineStart)}`;
+  }
+
+  if (output.includes('Hugging Face publisher')) {
+    throw new Error('Visible page still describes the clinic as the Hugging Face publisher.');
+  }
+  return output;
+}
+
+function normalizeLlmsGuide(source) {
+  let output = source;
+
+  output = output.replace(
+    '[Primary physician entity Dataset — JSON-LD knowledge graph](https://www.ghezelbaash.ir/graph.jsonld): Version 1.0.0',
+    '[Primary physician entity Dataset — JSON-LD knowledge graph](https://www.ghezelbaash.ir/graph.jsonld): Version 1.1.0',
+  );
+  output = output.replace(
+    '[Primary physician entity Dataset — RDF Turtle](https://www.ghezelbaash.ir/graph.ttl): Deterministic Version 1.0.0',
+    '[Primary physician entity Dataset — RDF Turtle](https://www.ghezelbaash.ir/graph.ttl): Deterministic Version 1.1.0',
+  );
+  output = output.replace(
+    '- Dataset name: Dr. Saeed Ghezelbaash Public Knowledge Graph\n- Dataset entity: https://www.ghezelbaash.ir/graph.jsonld#dataset\n- Version: 1.0.0',
+    '- Dataset name: Dr. Saeed Ghezelbash Entity Data\n- Dataset entity: https://www.ghezelbaash.ir/graph.jsonld#dataset\n- Version: 1.1.0',
+  );
+  output = output.replace(
+    '- Creator and publisher: https://www.ghezelbaash.ir/#saeed-ghezelbash',
+    '- Creator, publisher, owner, copyright holder and maintainer: https://www.ghezelbaash.ir/#saeed-ghezelbash',
+  );
+  output = output.replace(
+    'The complete knowledge graph is the primary Dataset content. JSON-LD and RDF Turtle are synchronized distributions of that same Dataset; a duplicate third file is intentionally avoided to prevent canonical and version drift.',
+    'The complete knowledge graph is one canonical physician-owned Dataset. The official website, GitHub, Hugging Face and Zenodo are synchronized identity and distribution channels for that same Dataset, not separate or derivative Datasets. JSON-LD and RDF Turtle are RDF-equivalent serializations of the same underlying graph. The clinic is Saeed Ghezelbash’s personally owned practice and any clinic-named hosting namespace remains under the physician’s ownership and control.',
+  );
+
+  const distributionLines = [
+    '- Hugging Face Dataset identity and distribution endpoint: https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data',
+    '- Zenodo archival identity and distribution endpoint: https://doi.org/10.5281/zenodo.18765169',
+    '- Wikidata structured-data asset identity: https://www.wikidata.org/wiki/Q140304972',
+  ].join('\n');
+  const insertionAnchor = '- RDF-equivalent Turtle distribution: https://www.ghezelbaash.ir/graph.ttl';
+  if (!output.includes(distributionLines) && output.includes(insertionAnchor)) {
+    output = output.replace(insertionAnchor, `${insertionAnchor}\n${distributionLines}`);
+  }
+
+  if (!output.includes('One canonical physician-owned Dataset') && !output.includes('one canonical physician-owned Dataset')) {
+    throw new Error('llms.txt did not receive the canonical Dataset ownership statement.');
+  }
+  if (!output.includes('Creator, publisher, owner, copyright holder and maintainer')) {
+    throw new Error('llms.txt does not identify Saeed Ghezelbash as the full Dataset authority.');
+  }
+  return output;
+}
+
+const page = normalizeVisiblePage(await readFile(PAGE_PATH, 'utf8'));
+const llms = normalizeLlmsGuide(await readFile(LLMS_PATH, 'utf8'));
+await writeFile(PAGE_PATH, page, 'utf8');
+await writeFile(LLMS_PATH, llms, 'utf8');
+console.log('Visible page and llms.txt aligned with the physician-owned one-Dataset/multiple-distributions model.');

--- a/scripts/retire-duplicate-datasets.mjs
+++ b/scripts/retire-duplicate-datasets.mjs
@@ -9,9 +9,9 @@ const GRAPH_PATHS = [
 ];
 
 const PRIMARY_DATASET_ID = 'https://www.ghezelbaash.ir/graph.jsonld#dataset';
-const HISTORICAL_DATASET_ID = 'https://www.ghezelbaash.ir/#historical-patient-origin-summary';
+const LEGACY_HUGGINGFACE_DATASET_ID = 'https://www.ghezelbaash.ir/#project-huggingface-dataset';
+const RETIRED_DATASET_IDS = new Set([LEGACY_HUGGINGFACE_DATASET_ID]);
 
-const asArray = (value) => (value == null ? [] : Array.isArray(value) ? value : [value]);
 const keyFor = (value) => {
   if (value && typeof value === 'object' && typeof value['@id'] === 'string') return `@id:${value['@id']}`;
   return JSON.stringify(value);
@@ -27,14 +27,14 @@ function unique(values) {
   });
 }
 
-function rewriteReferences(value, retiredIds) {
-  if (Array.isArray(value)) return unique(value.map((item) => rewriteReferences(item, retiredIds)));
+function rewriteReferences(value) {
+  if (Array.isArray(value)) return unique(value.map(rewriteReferences));
   if (!value || typeof value !== 'object') return value;
 
   const output = {};
   for (const [key, child] of Object.entries(value)) {
-    if (key === '@id' && retiredIds.has(child)) output[key] = PRIMARY_DATASET_ID;
-    else output[key] = rewriteReferences(child, retiredIds);
+    if (key === '@id' && RETIRED_DATASET_IDS.has(child)) output[key] = PRIMARY_DATASET_ID;
+    else output[key] = rewriteReferences(child);
   }
   return output;
 }
@@ -43,20 +43,19 @@ for (const filePath of GRAPH_PATHS) {
   const document = JSON.parse(await readFile(filePath, 'utf8'));
   if (!Array.isArray(document['@graph'])) throw new Error(`${path.relative(ROOT, filePath)} has no @graph array.`);
 
-  const retiredIds = new Set(
+  const presentRetiredIds = new Set(
     document['@graph']
-      .filter((node) => asArray(node?.['@type']).includes('Dataset'))
       .map((node) => node?.['@id'])
-      .filter((id) => id && id !== PRIMARY_DATASET_ID && id !== HISTORICAL_DATASET_ID),
+      .filter((id) => id && RETIRED_DATASET_IDS.has(id)),
   );
 
   document['@graph'] = document['@graph']
-    .filter((node) => !retiredIds.has(node?.['@id']))
-    .map((node) => rewriteReferences(node, retiredIds));
+    .filter((node) => !RETIRED_DATASET_IDS.has(node?.['@id']))
+    .map(rewriteReferences);
 
   await writeFile(filePath, `${JSON.stringify(document)}\n`, 'utf8');
   console.log(
-    `${path.relative(ROOT, filePath)}: retired ${retiredIds.size} duplicate Dataset node(s)` +
-      (retiredIds.size ? ` — ${[...retiredIds].join(', ')}` : ''),
+    `${path.relative(ROOT, filePath)}: retired ${presentRetiredIds.size} known duplicate Dataset node(s)` +
+      (presentRetiredIds.size ? ` — ${[...presentRetiredIds].join(', ')}` : ''),
   );
 }

--- a/scripts/retire-duplicate-datasets.mjs
+++ b/scripts/retire-duplicate-datasets.mjs
@@ -1,0 +1,62 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = process.cwd();
+const GRAPH_PATHS = [
+  path.join(ROOT, 'src/data/semantic/head-graph.min.jsonld'),
+  path.join(ROOT, 'public/graph.jsonld'),
+];
+
+const PRIMARY_DATASET_ID = 'https://www.ghezelbaash.ir/graph.jsonld#dataset';
+const HISTORICAL_DATASET_ID = 'https://www.ghezelbaash.ir/#historical-patient-origin-summary';
+
+const asArray = (value) => (value == null ? [] : Array.isArray(value) ? value : [value]);
+const keyFor = (value) => {
+  if (value && typeof value === 'object' && typeof value['@id'] === 'string') return `@id:${value['@id']}`;
+  return JSON.stringify(value);
+};
+
+function unique(values) {
+  const seen = new Set();
+  return values.filter((value) => {
+    const key = keyFor(value);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function rewriteReferences(value, retiredIds) {
+  if (Array.isArray(value)) return unique(value.map((item) => rewriteReferences(item, retiredIds)));
+  if (!value || typeof value !== 'object') return value;
+
+  const output = {};
+  for (const [key, child] of Object.entries(value)) {
+    if (key === '@id' && retiredIds.has(child)) output[key] = PRIMARY_DATASET_ID;
+    else output[key] = rewriteReferences(child, retiredIds);
+  }
+  return output;
+}
+
+for (const filePath of GRAPH_PATHS) {
+  const document = JSON.parse(await readFile(filePath, 'utf8'));
+  if (!Array.isArray(document['@graph'])) throw new Error(`${path.relative(ROOT, filePath)} has no @graph array.`);
+
+  const retiredIds = new Set(
+    document['@graph']
+      .filter((node) => asArray(node?.['@type']).includes('Dataset'))
+      .map((node) => node?.['@id'])
+      .filter((id) => id && id !== PRIMARY_DATASET_ID && id !== HISTORICAL_DATASET_ID),
+  );
+
+  document['@graph'] = document['@graph']
+    .filter((node) => !retiredIds.has(node?.['@id']))
+    .map((node) => rewriteReferences(node, retiredIds));
+
+  await writeFile(filePath, `${JSON.stringify(document)}\n`, 'utf8');
+  console.log(
+    `${path.relative(ROOT, filePath)}: retired ${retiredIds.size} duplicate Dataset node(s)` +
+      (retiredIds.size ? ` — ${[...retiredIds].join(', ')}` : ''),
+  );
+}

--- a/tests/dataset-entity.test.mjs
+++ b/tests/dataset-entity.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const PERSON_ID = 'https://www.ghezelbaash.ir/#saeed-ghezelbash';
+const CLINIC_ID = 'https://www.ghezelbaash.ir/#dr-saeed-ghezelbash-aesthetic-clinic-kermanshah';
+const PROJECT_ID = 'https://www.ghezelbaash.ir/#doctor-ghezelbaash-structured-data-project';
+const CATALOG_ID = 'https://www.ghezelbaash.ir/#data-catalog';
+const PRIMARY_DATASET_ID = 'https://www.ghezelbaash.ir/graph.jsonld#dataset';
+const HISTORICAL_DATASET_ID = 'https://www.ghezelbaash.ir/#historical-patient-origin-summary';
+const LEGACY_DATASET_ID = 'https://www.ghezelbaash.ir/#project-huggingface-dataset';
+const HF_DATASET_URL = 'https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data';
+const ZENODO_DOI_URL = 'https://doi.org/10.5281/zenodo.18765169';
+const WIKIDATA_PROJECT_URL = 'https://www.wikidata.org/entity/Q140304972';
+
+const files = {
+  head: 'src/data/semantic/head-graph.min.jsonld',
+  public: 'public/graph.jsonld',
+};
+
+const readJson = async (file) => JSON.parse(await readFile(file, 'utf8'));
+const asArray = (value) => (value == null ? [] : Array.isArray(value) ? value : [value]);
+const findNode = (document, id) => document['@graph'].find((node) => node?.['@id'] === id);
+const referenceIds = (value) => asArray(value).map((item) => item?.['@id']).filter(Boolean);
+
+function datasetProjection(node) {
+  return {
+    id: node['@id'],
+    type: node['@type'],
+    name: node.name,
+    description: node.description,
+    creator: node.creator,
+    publisher: node.publisher,
+    copyrightHolder: node.copyrightHolder,
+    maintainer: node.maintainer,
+    accountablePerson: node.accountablePerson,
+    about: node.about,
+    sameAs: node.sameAs,
+    identifier: node.identifier,
+    distribution: node.distribution,
+    includedInDataCatalog: node.includedInDataCatalog,
+    isAccessibleForFree: node.isAccessibleForFree,
+    license: node.license,
+    version: node.version,
+  };
+}
+
+for (const [label, file] of Object.entries(files)) {
+  test(`${label} graph has one canonical physician Dataset and no Hugging Face duplicate`, async () => {
+    const document = await readJson(file);
+    const serialized = JSON.stringify(document);
+    assert.equal(serialized.includes(LEGACY_DATASET_ID), false, 'retired duplicate Dataset identifier must be absent');
+
+    const datasets = document['@graph'].filter((node) => asArray(node?.['@type']).includes('Dataset'));
+    assert.equal(datasets.length, 2, 'only the canonical entity Dataset and historical supporting Dataset should remain');
+    assert.deepEqual(
+      new Set(datasets.map((node) => node['@id'])),
+      new Set([PRIMARY_DATASET_ID, HISTORICAL_DATASET_ID]),
+    );
+  });
+
+  test(`${label} graph makes Saeed Ghezelbash the Dataset authority`, async () => {
+    const document = await readJson(file);
+    const dataset = findNode(document, PRIMARY_DATASET_ID);
+    assert.ok(dataset, 'canonical Dataset node is required');
+    assert.equal(dataset.name, 'Dr. Saeed Ghezelbash Entity Data');
+    assert.ok(typeof dataset.description === 'string' && dataset.description.length >= 50 && dataset.description.length <= 5000);
+    assert.equal(dataset.creator?.['@id'], PERSON_ID);
+    assert.equal(dataset.publisher?.['@id'], PERSON_ID);
+    assert.equal(dataset.copyrightHolder?.['@id'], PERSON_ID);
+    assert.equal(dataset.maintainer?.['@id'], PERSON_ID);
+    assert.equal(dataset.accountablePerson?.['@id'], PERSON_ID);
+    assert.equal(dataset.includedInDataCatalog?.['@id'], CATALOG_ID);
+    assert.equal(dataset.isAccessibleForFree, true);
+    assert.equal(Object.hasOwn(dataset, 'isPartOf'), false, 'canonical Dataset must not be subordinated to a non-Dataset CreativeWork');
+    assert.equal(Object.hasOwn(dataset, 'isBasedOn'), false, 'repository mirrors are not derivative Datasets');
+
+    const aboutIds = new Set(referenceIds(dataset.about));
+    assert.ok(aboutIds.has(PERSON_ID));
+    assert.ok(aboutIds.has(CLINIC_ID));
+    assert.ok(aboutIds.has(PROJECT_ID));
+
+    assert.deepEqual(
+      new Set(asArray(dataset.sameAs)),
+      new Set([HF_DATASET_URL, ZENODO_DOI_URL, WIKIDATA_PROJECT_URL]),
+    );
+  });
+
+  test(`${label} graph keeps reciprocal catalog and repository links`, async () => {
+    const document = await readJson(file);
+    const catalog = findNode(document, CATALOG_ID);
+    const project = findNode(document, PROJECT_ID);
+    const person = findNode(document, PERSON_ID);
+    const clinic = findNode(document, CLINIC_ID);
+
+    assert.deepEqual(new Set(referenceIds(catalog.dataset)), new Set([PRIMARY_DATASET_ID, HISTORICAL_DATASET_ID]));
+    assert.ok(referenceIds(project.hasPart).includes(PRIMARY_DATASET_ID));
+    assert.ok(referenceIds(person.subjectOf).includes(PRIMARY_DATASET_ID));
+    assert.ok(referenceIds(clinic.subjectOf).includes(PRIMARY_DATASET_ID));
+    assert.equal(project.owner?.['@id'], PERSON_ID);
+    assert.equal(project.creator?.['@id'], PERSON_ID);
+    assert.equal(project.publisher?.['@id'], PERSON_ID);
+    assert.equal(project.copyrightHolder?.['@id'], PERSON_ID);
+  });
+}
+
+test('embedded and public JSON-LD expose the same canonical Dataset statement', async () => {
+  const [head, publicGraph] = await Promise.all([readJson(files.head), readJson(files.public)]);
+  assert.deepEqual(
+    datasetProjection(findNode(head, PRIMARY_DATASET_ID)),
+    datasetProjection(findNode(publicGraph, PRIMARY_DATASET_ID)),
+  );
+});
+
+test('Turtle is non-empty and carries the canonical Dataset ownership triples', async () => {
+  const turtle = await readFile('public/graph.ttl', 'utf8');
+  assert.ok(turtle.length > 1000, 'Turtle distribution must contain the generated public graph');
+  assert.match(
+    turtle,
+    new RegExp(`<${PRIMARY_DATASET_ID.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/Dataset> \\.`),
+  );
+  assert.ok(turtle.includes(`<${PRIMARY_DATASET_ID}> <https://schema.org/publisher> <${PERSON_ID}> .`));
+  assert.ok(turtle.includes(`<${PRIMARY_DATASET_ID}> <https://schema.org/copyrightHolder> <${PERSON_ID}> .`));
+  assert.equal(turtle.includes(LEGACY_DATASET_ID), false);
+});

--- a/tests/dataset-entity.test.mjs
+++ b/tests/dataset-entity.test.mjs
@@ -8,6 +8,7 @@ const PROJECT_ID = 'https://www.ghezelbaash.ir/#doctor-ghezelbaash-structured-da
 const CATALOG_ID = 'https://www.ghezelbaash.ir/#data-catalog';
 const PRIMARY_DATASET_ID = 'https://www.ghezelbaash.ir/graph.jsonld#dataset';
 const HISTORICAL_DATASET_ID = 'https://www.ghezelbaash.ir/#historical-patient-origin-summary';
+const REPUTATION_SNAPSHOT_ID = 'https://www.ghezelbaash.ir/#google-maps-reputation-snapshot-current';
 const LEGACY_DATASET_ID = 'https://www.ghezelbaash.ir/#project-huggingface-dataset';
 const HF_DATASET_URL = 'https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data';
 const ZENODO_DOI_URL = 'https://doi.org/10.5281/zenodo.18765169';
@@ -22,6 +23,7 @@ const readJson = async (file) => JSON.parse(await readFile(file, 'utf8'));
 const asArray = (value) => (value == null ? [] : Array.isArray(value) ? value : [value]);
 const findNode = (document, id) => document['@graph'].find((node) => node?.['@id'] === id);
 const referenceIds = (value) => asArray(value).map((item) => item?.['@id']).filter(Boolean);
+const datasetNodes = (document) => document['@graph'].filter((node) => asArray(node?.['@type']).includes('Dataset'));
 
 function datasetProjection(node) {
   return {
@@ -46,20 +48,18 @@ function datasetProjection(node) {
 }
 
 for (const [label, file] of Object.entries(files)) {
-  test(`${label} graph has one canonical physician Dataset and no Hugging Face duplicate`, async () => {
+  test(`${label} graph has one canonical Dataset and no duplicate Hugging Face Dataset`, async () => {
     const document = await readJson(file);
     const serialized = JSON.stringify(document);
     assert.equal(serialized.includes(LEGACY_DATASET_ID), false, 'retired duplicate Dataset identifier must be absent');
 
-    const datasets = document['@graph'].filter((node) => asArray(node?.['@type']).includes('Dataset'));
-    assert.equal(datasets.length, 2, 'only the canonical entity Dataset and historical supporting Dataset should remain');
-    assert.deepEqual(
-      new Set(datasets.map((node) => node['@id'])),
-      new Set([PRIMARY_DATASET_ID, HISTORICAL_DATASET_ID]),
-    );
+    const datasets = datasetNodes(document);
+    assert.equal(datasets.filter((node) => node['@id'] === PRIMARY_DATASET_ID).length, 1);
+    assert.ok(datasets.some((node) => node['@id'] === HISTORICAL_DATASET_ID));
+    if (label === 'public') assert.ok(datasets.some((node) => node['@id'] === REPUTATION_SNAPSHOT_ID));
   });
 
-  test(`${label} graph makes Saeed Ghezelbash the Dataset authority`, async () => {
+  test(`${label} graph makes Saeed Ghezelbash the canonical Dataset authority`, async () => {
     const document = await readJson(file);
     const dataset = findNode(document, PRIMARY_DATASET_ID);
     assert.ok(dataset, 'canonical Dataset node is required');
@@ -86,15 +86,32 @@ for (const [label, file] of Object.entries(files)) {
     );
   });
 
+  test(`${label} graph preserves distinct supporting Datasets under physician ownership`, async () => {
+    const document = await readJson(file);
+    const supporting = datasetNodes(document).filter((node) => node['@id'] !== PRIMARY_DATASET_ID);
+    assert.ok(supporting.length >= 1);
+
+    for (const dataset of supporting) {
+      assert.equal(dataset.creator?.['@id'], PERSON_ID, `${dataset['@id']} creator`);
+      assert.equal(dataset.publisher?.['@id'], PERSON_ID, `${dataset['@id']} publisher`);
+      assert.equal(dataset.copyrightHolder?.['@id'], PERSON_ID, `${dataset['@id']} copyrightHolder`);
+      assert.equal(dataset.maintainer?.['@id'], PERSON_ID, `${dataset['@id']} maintainer`);
+      assert.equal(dataset.accountablePerson?.['@id'], PERSON_ID, `${dataset['@id']} accountablePerson`);
+      assert.equal(dataset.includedInDataCatalog?.['@id'], CATALOG_ID, `${dataset['@id']} catalog`);
+      assert.equal(dataset.isPartOf?.['@id'], PRIMARY_DATASET_ID, `${dataset['@id']} parent Dataset`);
+    }
+  });
+
   test(`${label} graph keeps reciprocal catalog and repository links`, async () => {
     const document = await readJson(file);
     const catalog = findNode(document, CATALOG_ID);
     const project = findNode(document, PROJECT_ID);
     const person = findNode(document, PERSON_ID);
     const clinic = findNode(document, CLINIC_ID);
+    const allDatasetIds = datasetNodes(document).map((node) => node['@id']);
 
-    assert.deepEqual(new Set(referenceIds(catalog.dataset)), new Set([PRIMARY_DATASET_ID, HISTORICAL_DATASET_ID]));
-    assert.ok(referenceIds(project.hasPart).includes(PRIMARY_DATASET_ID));
+    assert.deepEqual(new Set(referenceIds(catalog.dataset)), new Set(allDatasetIds));
+    for (const id of allDatasetIds) assert.ok(referenceIds(project.hasPart).includes(id), `repository must include ${id}`);
     assert.ok(referenceIds(person.subjectOf).includes(PRIMARY_DATASET_ID));
     assert.ok(referenceIds(clinic.subjectOf).includes(PRIMARY_DATASET_ID));
     assert.equal(project.owner?.['@id'], PERSON_ID);
@@ -112,7 +129,7 @@ test('embedded and public JSON-LD expose the same canonical Dataset statement', 
   );
 });
 
-test('Turtle is non-empty and carries the canonical Dataset ownership triples', async () => {
+test('Turtle is non-empty and carries canonical ownership without the retired duplicate', async () => {
   const turtle = await readFile('public/graph.ttl', 'utf8');
   assert.ok(turtle.length > 1000, 'Turtle distribution must contain the generated public graph');
   assert.match(
@@ -121,5 +138,6 @@ test('Turtle is non-empty and carries the canonical Dataset ownership triples', 
   );
   assert.ok(turtle.includes(`<${PRIMARY_DATASET_ID}> <https://schema.org/publisher> <${PERSON_ID}> .`));
   assert.ok(turtle.includes(`<${PRIMARY_DATASET_ID}> <https://schema.org/copyrightHolder> <${PERSON_ID}> .`));
+  assert.ok(turtle.includes(`<${REPUTATION_SNAPSHOT_ID}> <https://schema.org/publisher> <${PERSON_ID}> .`));
   assert.equal(turtle.includes(LEGACY_DATASET_ID), false);
 });

--- a/tests/visible-dataset-copy.test.mjs
+++ b/tests/visible-dataset-copy.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const pagePath = 'src/pages/index.md';
+const llmsPath = 'public/llms.txt';
+
+test('visible page states physician ownership and does not call the clinic the Hugging Face publisher', async () => {
+  const page = await readFile(pagePath, 'utf8');
+  assert.ok(page.includes('id="canonical-dataset-ownership"'));
+  assert.ok(page.includes('یک Dataset کانونیکال واحد'));
+  assert.ok(page.includes('Saeed Ghezelbash is the creator, publisher, owner, copyright holder and maintainer'));
+  assert.equal(page.includes('Hugging Face publisher'), false);
+});
+
+test('llms.txt exposes one Dataset with synchronized website, GitHub, Hugging Face and Zenodo distributions', async () => {
+  const llms = await readFile(llmsPath, 'utf8');
+  assert.ok(llms.includes('Dataset name: Dr. Saeed Ghezelbash Entity Data'));
+  assert.ok(llms.includes('Version: 1.1.0'));
+  assert.ok(llms.includes('Creator, publisher, owner, copyright holder and maintainer'));
+  assert.ok(llms.includes('one canonical physician-owned Dataset'));
+  assert.ok(llms.includes('Hugging Face Dataset identity and distribution endpoint'));
+  assert.ok(llms.includes('Zenodo archival identity and distribution endpoint'));
+  assert.equal(llms.includes('Hugging Face publisher'), false);
+});


### PR DESCRIPTION
## Root cause
The structured-data graph modeled the Hugging Face publication as an additional standalone Dataset (`#project-huggingface-dataset`). That duplicate node lacked the required `description`, assigned the physician-owned clinic as publisher instead of Saeed Ghezelbash, and used `isPartOf` with a CreativeWork. This produced the Search Console Dataset error and contradicted the intended one-Dataset/multiple-distributions architecture. A second source defect was an empty `public/graph.ttl` file.

## Changes
- Retire only the duplicate Hugging Face Dataset node and rewrite its references to the canonical Dataset (`graph.jsonld#dataset`).
- Preserve genuinely distinct supporting Datasets, including the historical patient-origin Dataset and the Google Maps reputation snapshot.
- Make Saeed Ghezelbash the canonical Dataset creator, publisher, copyright holder, maintainer and accountable person.
- Make all supporting Datasets and the structured-data repository explicitly physician-owned and physician-published.
- Model Hugging Face, Zenodo and Wikidata Q140304972 as identity/distribution endpoints for the same canonical Dataset.
- Keep JSON-LD and Turtle files as synchronized distributions of that Dataset.
- Ensure reciprocal `DataCatalog.dataset`, repository `hasPart`, Person `subjectOf` and clinic `subjectOf` links.
- Remove invalid `isPartOf` and inappropriate `isBasedOn` from the canonical Dataset.
- Generate a complete non-empty Turtle graph from normalized public JSON-LD.
- Align visible page copy and `llms.txt` with the one canonical physician-owned Dataset / multiple synchronized distributions model.
- Replace the misleading visible “Hugging Face publisher” label with “Hugging Face hosting namespace”; the clinic-named namespace is explicitly described as a physician-owned hosting location, not an independent publisher.
- Add regression tests preventing reintroduction of the duplicate Dataset, clinic-as-publisher model, empty Turtle output or contradictory visible copy.

## Deployment behavior
`precheck`, `pretest`, `prebuild` and `predev` run the idempotent normalizers, so the visible source, LLM guide, embedded head graph, public JSON-LD and Turtle outputs are synchronized before Astro validation and Cloudflare Pages deployment.