### PR TITLE
Materialize canonical Dataset outputs in source

### DIFF
--- a/.github/workflows/materialize-canonical-data.yml
+++ b/.github/workflows/materialize-canonical-data.yml
@@ -1,6 +1,9 @@
 name: Materialize Canonical Data
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -10,7 +13,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: materialize-canonical-data
+  group: materialize-canonical-data-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -18,10 +21,10 @@ jobs:
     if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-24.04
     steps:
-      - name: Check out main
+      - name: Check out target branch
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'main' }}
           fetch-depth: 0
 
       - name: Use Node.js 24
@@ -58,7 +61,8 @@ jobs:
             exit 0
           fi
 
+          TARGET_BRANCH="${GITHUB_HEAD_REF:-main}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "chore(structured-data): materialize canonical Dataset outputs"
-          git push origin HEAD:main
+          git push origin "HEAD:${TARGET_BRANCH}"


### PR DESCRIPTION
## Purpose
The canonical Dataset normalizers already pass all checks and produce correct build output, but the generated JSON-LD, Turtle, visible copy and `llms.txt` must also be committed into Git so the repository itself is healthy and downstream synchronization to Hugging Face and Zenodo does not depend on a particular Cloudflare build command.

## Behavior
This PR makes the materialization workflow run on same-repository pull requests, normalize and validate the branch, then commit only these authoritative outputs back to the PR branch:
- `src/pages/index.md`
- `public/llms.txt`
- `src/data/semantic/head-graph.min.jsonld`
- `public/graph.jsonld`
- `public/graph.ttl`

The bot-authored follow-up event is skipped, preventing loops. The PR will be merged only after the generated source files appear in its diff and all validation checks pass.