### PR TITLE
fix(perf): restore lean authority observability

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -72,7 +72,7 @@ jobs:
     needs: validate
     name: Exact Cloudflare deployment and production contract
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    timeout-minutes: 18
 
     steps:
       - name: Check out repository

--- a/scripts/analyze-build-performance.mjs
+++ b/scripts/analyze-build-performance.mjs
@@ -6,6 +6,10 @@ import process from 'node:process';
 import { brotliCompressSync, constants as zlibConstants, gzipSync } from 'node:zlib';
 import { parse } from 'parse5';
 
+const IDENTITY_TEXT_MARKER = 'دکتر سعید قزلباش';
+const IDENTITY_TEXT_PATTERN = /دکتر\s+(?:محمد\s*)?سعید\s+قزلباش/u;
+const IDENTITY_LEAD_PATTERN = /دکتر\s+(?:محمد\s*)?سعید/u;
+
 function sha256(value) {
   return createHash('sha256').update(value).digest('hex');
 }
@@ -59,6 +63,8 @@ export function inspectHtml(html) {
   const fragmentIds = [];
   const imageAlts = [];
   const jsonLdScripts = [];
+  const stylesheets = [];
+  const preloads = [];
   let totalElements = 0;
   let maxDepth = 0;
   let head = null;
@@ -87,6 +93,22 @@ export function inspectHtml(html) {
       }
 
       if (node.tagName === 'img') imageAlts.push(attribute(node, 'alt'));
+
+      if (node.tagName === 'link') {
+        const rel = attribute(node, 'rel').toLowerCase().split(/\s+/).filter(Boolean);
+        const href = attribute(node, 'href');
+        if (rel.includes('stylesheet')) stylesheets.push(href);
+        if (rel.includes('preload')) {
+          preloads.push({
+            href,
+            as: attribute(node, 'as'),
+            type: attribute(node, 'type'),
+            media: attribute(node, 'media'),
+            fetchpriority: attribute(node, 'fetchpriority'),
+          });
+        }
+      }
+
       if (node.tagName === 'script' && attribute(node, 'type').toLowerCase() === 'application/ld+json') {
         const markup = sourceMarkup(html, node);
         const payload = scriptPayload(html, node);
@@ -101,6 +123,9 @@ export function inspectHtml(html) {
 
   const count = (tagName) => tagCounts.get(tagName) ?? 0;
   const mainDirectChildren = main?.childNodes?.filter(isElement).length ?? 0;
+  const tagHistogram = Object.fromEntries(
+    [...tagCounts.entries()].sort(([left], [right]) => left.localeCompare(right)),
+  );
 
   return {
     document,
@@ -113,6 +138,9 @@ export function inspectHtml(html) {
     headings,
     fragmentIds,
     imageAlts,
+    stylesheets,
+    preloads,
+    tagHistogram,
     counts: {
       images: count('img'),
       links: count('a'),
@@ -129,6 +157,12 @@ export function analyzeHtml(html, source = {}) {
   const headMarkup = sourceMarkup(html, inspected.head);
   const mainMarkup = sourceMarkup(html, inspected.main);
   const normalizedMainText = normalizedText(inspected.main ?? { childNodes: [] });
+  const identityMatch = IDENTITY_TEXT_PATTERN.exec(normalizedMainText);
+  const normalizedIdentityCharacterOffset = identityMatch?.index ?? -1;
+  const rawIdentityCharacterOffset = identityMatch ? html.search(IDENTITY_LEAD_PATTERN) : -1;
+  const rawIdentityByteOffset = rawIdentityCharacterOffset < 0
+    ? null
+    : byteLength(html.slice(0, rawIdentityCharacterOffset));
   const rawBytes = byteLength(html);
   const gzipBytes = gzipSync(Buffer.from(html), { level: 9 }).byteLength;
   const brotliBytes = brotliCompressSync(Buffer.from(html), {
@@ -139,6 +173,8 @@ export function analyzeHtml(html, source = {}) {
   }).byteLength;
   const jsonLdMarkup = inspected.jsonLdScripts.map(({ markup }) => markup).join('\n');
   const jsonLdPayload = inspected.jsonLdScripts.map(({ payload }) => payload).join('\n');
+  const headBytes = byteLength(headMarkup);
+  const mainBytes = byteLength(mainMarkup);
 
   return {
     schemaVersion: 2,
@@ -150,10 +186,20 @@ export function analyzeHtml(html, source = {}) {
       gzipBytes,
       brotliBytes,
       sha256: sha256(html),
+      compressionRatios: {
+        gzip: rawBytes ? Number((gzipBytes / rawBytes).toFixed(6)) : 0,
+        brotli: rawBytes ? Number((brotliBytes / rawBytes).toFixed(6)) : 0,
+      },
     },
     regions: {
-      head: { rawBytes: byteLength(headMarkup) },
-      main: { rawBytes: byteLength(mainMarkup) },
+      head: {
+        rawBytes: headBytes,
+        shareOfDocument: rawBytes ? Number((headBytes / rawBytes).toFixed(6)) : 0,
+      },
+      main: {
+        rawBytes: mainBytes,
+        shareOfDocument: rawBytes ? Number((mainBytes / rawBytes).toFixed(6)) : 0,
+      },
       inlineJsonLd: {
         count: inspected.jsonLdScripts.length,
         markupBytes: byteLength(jsonLdMarkup),
@@ -168,6 +214,21 @@ export function analyzeHtml(html, source = {}) {
       headings: inspected.headings.length,
       fragmentIds: inspected.fragmentIds.length,
       ...inspected.counts,
+      tagHistogram: inspected.tagHistogram,
+    },
+    criticalPathInventory: {
+      stylesheets: inspected.stylesheets,
+      preloads: inspected.preloads,
+      identityText: {
+        marker: IDENTITY_TEXT_MARKER,
+        matchedText: identityMatch?.[0] ?? null,
+        found: normalizedIdentityCharacterOffset >= 0,
+        normalizedTextCharacterOffset: normalizedIdentityCharacterOffset,
+        rawByteOffset: rawIdentityByteOffset,
+        shareOfNormalizedMainText: normalizedIdentityCharacterOffset >= 0 && normalizedMainText.length
+          ? Number((normalizedIdentityCharacterOffset / normalizedMainText.length).toFixed(6))
+          : null,
+      },
     },
     fingerprints: {
       normalizedMainTextSha256: sha256(normalizedMainText),

--- a/tests/performance-observatory.test.mjs
+++ b/tests/performance-observatory.test.mjs
@@ -13,19 +13,32 @@ test('parse5 analyzer measures DOM nodes without counting HTML-like JSON-LD text
   assert.equal(inspected.maxDepth, 5);
   assert.equal(inspected.headings[0].text, 'خدمات');
   assert.equal(inspected.jsonLdScripts.length, 1);
+  assert.deepEqual(inspected.stylesheets, ['/a.css']);
+  assert.deepEqual(inspected.preloads, []);
+  assert.equal(inspected.tagHistogram.script, 1);
 });
 
-test('performance report records stable size and authority-preserving fingerprints', () => {
+test('performance report records compact authority and critical-path observability', () => {
   const report = analyzeHtml(FIXTURE, { commit: 'fixture' });
   assert.equal(report.schemaVersion, 2);
   assert.equal(report.regions.inlineJsonLd.count, 1);
   assert.equal(report.dom.totalElements, 13);
   assert.equal(report.dom.mainDirectChildren, 3);
+  assert.equal(report.dom.tagHistogram.main, 1);
   assert.match(report.document.sha256, /^[a-f0-9]{64}$/);
+  assert.ok(report.document.compressionRatios.gzip > 0);
+  assert.ok(report.document.compressionRatios.brotli > 0);
+  assert.ok(report.regions.head.shareOfDocument > 0);
+  assert.ok(report.regions.main.shareOfDocument > 0);
+  assert.deepEqual(report.criticalPathInventory.stylesheets, ['/a.css']);
+  assert.deepEqual(report.criticalPathInventory.preloads, []);
+  assert.equal(report.criticalPathInventory.identityText.marker, 'دکتر سعید قزلباش');
+  assert.equal(report.criticalPathInventory.identityText.matchedText, 'دکتر سعید قزلباش');
+  assert.equal(report.criticalPathInventory.identityText.found, true);
+  assert.ok(report.criticalPathInventory.identityText.rawByteOffset >= 0);
   assert.match(report.fingerprints.normalizedMainTextSha256, /^[a-f0-9]{64}$/);
   assert.match(report.fingerprints.headingSequenceSha256, /^[a-f0-9]{64}$/);
   assert.equal(report.budgets.enforcement, 'observation-only');
-  assert.equal('criticalPathInventory' in report, false);
 });
 
 test('Cloudflare check selection only accepts the official app and newest exact check', () => {


### PR DESCRIPTION
## Summary

Restore the authority and critical-path metrics removed by the latest observability refactor while keeping the parse5 implementation and the single existing analyzer.

## Changes

- restore stylesheet and preload inventory in the existing analyzer
- restore physician identity presence and position metrics
- restore compression ratios, region shares, and tag histogram
- cover the restored fields in the existing observatory test
- align the production verification timeout with its configured retry budget

## Scope control

- no new files
- no parallel analyzer or provenance endpoint
- no page, structured-data, CSS, routing, or content changes