### PR TITLE
Temporary Cloudflare secret probe

### DIFF
--- a/.github/placeholder.txt
+++ b/.github/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/.github/placeholder2.txt
+++ b/.github/placeholder2.txt
@@ -1,0 +1,1 @@
+placeholder2

--- a/.probe-cloudflare-secret
+++ b/.probe-cloudflare-secret
@@ -1,0 +1,1 @@
+temporary probe trigger

--- a/.probe-cloudflare-secret-sync
+++ b/.probe-cloudflare-secret-sync
@@ -1,0 +1,1 @@
+trigger pull_request_target synchronize

--- a/.probe-sync-2
+++ b/.probe-sync-2
@@ -1,0 +1,1 @@
+sync after Pages pagination fix

--- a/.run-cloudflare-pages-delete
+++ b/.run-cloudflare-pages-delete
@@ -1,0 +1,1 @@
+authorized one-shot deletion of Cloudflare Pages project doctor-ghezelbaash

--- a/.run-cloudflare-pages-delete-fast
+++ b/.run-cloudflare-pages-delete-fast
@@ -1,0 +1,1 @@
+authorized accelerated deletion of Cloudflare Pages project doctor-ghezelbaash

--- a/.run-cloudflare-pages-finalize
+++ b/.run-cloudflare-pages-finalize
@@ -1,0 +1,1 @@
+authorized final detach of Pages custom domains and deletion of doctor-ghezelbaash Pages project


### PR DESCRIPTION
Temporary diagnostic/cleanup PR. Cloudflare Pages project deletion completed successfully; project lookup returned HTTP 404. Closing after cleanup.