### PR TITLE
Temporary pages.dev subdomain canonicalization

### DIFF
--- a/.github/cloudflare-pagesdev-subdomains-finalize-trigger.txt
+++ b/.github/cloudflare-pagesdev-subdomains-finalize-trigger.txt
@@ -1,2 +1,3 @@
 trigger 2026-08-09 include pages.dev deployment subdomains
 rerun with current deployment explicit redirect
+read-only verify permanent canonicalization pipeline

--- a/.github/cloudflare-pagesdev-subdomains-finalize-trigger.txt
+++ b/.github/cloudflare-pagesdev-subdomains-finalize-trigger.txt
@@ -1,1 +1,2 @@
 trigger 2026-08-09 include pages.dev deployment subdomains
+rerun with current deployment explicit redirect

--- a/.github/cloudflare-pagesdev-subdomains-finalize-trigger.txt
+++ b/.github/cloudflare-pagesdev-subdomains-finalize-trigger.txt
@@ -1,0 +1,1 @@
+trigger 2026-08-09 include pages.dev deployment subdomains


### PR DESCRIPTION
One-shot Pages hostname canonicalization completed. The stable doctor-ghezelbaash.pages.dev hostname and the current unique production deployment hostname both returned exact HTTP 301 redirects to https://www.ghezelbaash.ir/ with path/query preservation. The permanent production deploy workflow now carries this forward on every main deployment and preserves prior deployment-host redirects. Temporary verifier removed from main; closing without merge.