### PR TITLE
chore: temporary secret access probe

### DIFF
--- a/.github/workflows/secret-access-probe.yml
+++ b/.github/workflows/secret-access-probe.yml
@@ -1,0 +1,82 @@
+name: Secret Access Probe
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    env:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      ZENODO_ACCESS_TOKEN: ${{ secrets.ZENODO_ACCESS_TOKEN }}
+    steps:
+      - name: Install probe dependency
+        run: python -m pip install --quiet huggingface_hub requests
+
+      - name: Validate Hugging Face and Zenodo access
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+          import requests
+          from huggingface_hub import HfApi
+
+          hf = os.environ.get("HF_TOKEN", "")
+          zen = os.environ.get("ZENODO_ACCESS_TOKEN", "")
+
+          print(f"HF_SECRET_PRESENT={int(bool(hf))}")
+          print(f"ZENODO_SECRET_PRESENT={int(bool(zen))}")
+
+          failed = False
+
+          if hf:
+              try:
+                  api = HfApi(token=hf)
+                  info = api.whoami(token=hf)
+                  print("HF_AUTH_OK=1")
+                  print("HF_USER=" + str(info.get("name", "unknown")))
+                  api.auth_check(
+                      repo_id="doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data",
+                      repo_type="dataset",
+                      token=hf,
+                      write=True,
+                  )
+                  print("HF_WRITE_OK=1")
+              except Exception as exc:
+                  print("HF_WRITE_OK=0")
+                  print("HF_ERROR_TYPE=" + type(exc).__name__)
+                  failed = True
+          else:
+              print("HF_AUTH_OK=0")
+              print("HF_WRITE_OK=0")
+              failed = True
+
+          if zen:
+              try:
+                  response = requests.get(
+                      "https://zenodo.org/api/deposit/depositions",
+                      headers={"Authorization": f"Bearer {zen}"},
+                      params={"size": 1},
+                      timeout=30,
+                  )
+                  print("ZENODO_HTTP=" + str(response.status_code))
+                  if response.status_code == 200:
+                      print("ZENODO_AUTH_OK=1")
+                  else:
+                      print("ZENODO_AUTH_OK=0")
+                      failed = True
+              except Exception as exc:
+                  print("ZENODO_AUTH_OK=0")
+                  print("ZENODO_ERROR_TYPE=" + type(exc).__name__)
+                  failed = True
+          else:
+              print("ZENODO_AUTH_OK=0")
+              failed = True
+
+          sys.exit(1 if failed else 0)
+          PY

--- a/.github/workflows/secret-access-probe.yml
+++ b/.github/workflows/secret-access-probe.yml
@@ -1,3 +1,4 @@
+# temporary verification workflow; remove after probe
 name: Secret Access Probe
 
 on:


### PR DESCRIPTION
Temporary same-repository PR to validate GitHub Actions access to HF_TOKEN and ZENODO_ACCESS_TOKEN without exposing secret values. This will be closed after verification.