### PR TITLE
Preserve main-only release audit history in final convergence branch

### DIFF
--- a/.github/workflows/debug-v1-1-source-on-issue.yml
+++ b/.github/workflows/debug-v1-1-source-on-issue.yml
@@ -37,6 +37,7 @@ jobs:
           }
           run_cmd node scripts/finalize-release-source-v1.1.mjs
           RC=$?
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/stamp-release-media-v1.1.mjs; RC=$?; fi
           if [ "$RC" -eq 0 ]; then run_cmd node scripts/validate-release-contract.mjs; RC=$?; fi
           if [ "$RC" -eq 0 ]; then run_cmd npm ci; RC=$?; fi
           if [ "$RC" -eq 0 ]; then run_cmd npm run prepare:generated; RC=$?; fi

--- a/.github/workflows/debug-v1-1-source-on-issue.yml
+++ b/.github/workflows/debug-v1-1-source-on-issue.yml
@@ -1,0 +1,46 @@
+name: Debug v1.1 source migration on issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  debug:
+    if: github.event.issue.title == 'DEBUG-V1.1-SOURCE-MIGRATION'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/v1.1.0-doi-gate
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+      - name: Run migration and validator with captured diagnostics
+        shell: bash
+        run: |
+          set +e
+          node scripts/finalize-release-source-v1.1.mjs > /tmp/debug.log 2>&1
+          RC1=$?
+          if [ "$RC1" -eq 0 ]; then
+            node scripts/validate-release-contract.mjs >> /tmp/debug.log 2>&1
+            RC2=$?
+          else
+            RC2=99
+          fi
+          python - <<'PY' > /tmp/body.txt
+          from pathlib import Path
+          text=Path('/tmp/debug.log').read_text(errors='replace')
+          text=text[-5000:]
+          print('V1_1_SOURCE_DEBUG_RESULT\n```text\n'+text.replace('```','` ` `')+'\n```')
+          PY
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt
+          test "$RC1" -eq 0 && test "$RC2" -eq 0

--- a/.github/workflows/debug-v1-1-source-on-issue.yml
+++ b/.github/workflows/debug-v1-1-source-on-issue.yml
@@ -1,4 +1,4 @@
-name: Debug v1.1 source migration on issue
+name: Debug v1.1 full source preparation on issue
 
 on:
   issues:
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   debug:
-    if: github.event.issue.title == 'DEBUG-V1.1-SOURCE-MIGRATION'
+    if: github.event.issue.title == 'DEBUG-V1.1-FULL-SOURCE'
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     env:
       GH_TOKEN: ${{ github.token }}
       ISSUE: ${{ github.event.issue.number }}
@@ -24,23 +24,28 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24.18.0
-      - name: Run migration and validator with captured diagnostics
+          cache: npm
+      - name: Run full Stage 5 preparation with captured diagnostics
         shell: bash
         run: |
           set +e
-          node scripts/finalize-release-source-v1.1.mjs > /tmp/debug.log 2>&1
-          RC1=$?
-          if [ "$RC1" -eq 0 ]; then
-            node scripts/validate-release-contract.mjs >> /tmp/debug.log 2>&1
-            RC2=$?
-          else
-            RC2=99
-          fi
+          : > /tmp/debug.log
+          run_cmd() {
+            echo "===== $* =====" >> /tmp/debug.log
+            "$@" >> /tmp/debug.log 2>&1
+            return $?
+          }
+          run_cmd node scripts/finalize-release-source-v1.1.mjs
+          RC=$?
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/validate-release-contract.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm ci; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm run prepare:generated; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm run release:prepare; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/validate-release-contract.mjs; RC=$?; fi
           python - <<'PY' > /tmp/body.txt
           from pathlib import Path
-          text=Path('/tmp/debug.log').read_text(errors='replace')
-          text=text[-5000:]
-          print('V1_1_SOURCE_DEBUG_RESULT\n```text\n'+text.replace('```','` ` `')+'\n```')
+          text=Path('/tmp/debug.log').read_text(errors='replace')[-12000:]
+          print('V1_1_FULL_SOURCE_DEBUG_RESULT\n```text\n'+text.replace('```','` ` `')+'\n```')
           PY
           gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt
-          test "$RC1" -eq 0 && test "$RC2" -eq 0
+          exit "$RC"

--- a/.github/workflows/deploy-frozen-v1-1-cloudflare-on-issue.yml
+++ b/.github/workflows/deploy-frozen-v1-1-cloudflare-on-issue.yml
@@ -1,0 +1,123 @@
+name: Deploy immutable v1.1.0 frozen release to Cloudflare
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  deploy:
+    if: github.event.issue.title == 'DEPLOY-CLOUDFLARE-V1.1-FROZEN'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+      CLOUDFLARE_ACCOUNT_ID: '884d1d90bd1fb6ecca14992c6c60d677'
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_PROJECT: 'doctor-ghezelbaash'
+      CANONICAL: 'https://www.ghezelbaash.ir'
+      VERSION_DOI: '10.5281/zenodo.21886743'
+    steps:
+      - name: Verify Cloudflare credential and Zenodo publication gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${CLOUDFLARE_API_TOKEN:-}" || { echo 'Cloudflare credential unavailable' >&2; exit 78; }
+          python - <<'PY'
+          import json,urllib.request
+          with urllib.request.urlopen('https://zenodo.org/api/records/21886743',timeout=30) as r:
+              p=json.load(r)
+          assert p.get('doi')=='10.5281/zenodo.21886743'
+          assert (p.get('metadata') or {}).get('version')=='1.1.0'
+          print('ZENODO_PUBLICATION_GATE_PASS')
+          PY
+
+      - name: Download exact frozen release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dr-saeed-ghezelbash-v1.1.0-frozen-release
+          path: /tmp/frozen-v1.1.0
+          github-token: ${{ github.token }}
+          repository: medicaldoctor91/doctor-ghezelbaash
+          run-id: 31481133028
+
+      - name: Verify immutable payload before deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib,json
+          from pathlib import Path
+          root=Path('/tmp/frozen-v1.1.0'); dist=root/'dist'
+          hashes=json.loads((root/'dist-sha256.json').read_text()); att=json.loads((root/'release-attestation.json').read_text())
+          assert att['release']=='1.1.0' and att['coreFrozen'] is True and att['zenodoVersionDoi']=='10.5281/zenodo.21886743'
+          for n in ['index.html','graph.jsonld','graph.ttl','entity-facts.csv','answers.txt','knowledge.xml','llms.txt','llms-full.txt','index.md','datapackage.json','croissant.json','dcat.ttl','void.ttl','linkset.json','provenance.jsonld','evidence-snapshot.json','shapes.ttl','artifact-manifest.json']:
+              p=dist/n; assert p.is_file() and hashlib.sha256(p.read_bytes()).hexdigest()==hashes[n],n
+          print('FROZEN_WEBSITE_PAYLOAD_PASS')
+          PY
+
+      - name: Deploy frozen DIST directly to Cloudflare Pages production
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.120.0 pages deploy /tmp/frozen-v1.1.0/dist --project-name="$CF_PROJECT" --branch=main --commit-dirty=true
+
+      - name: Verify canonical production bytes, headers, DOI and domain state
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib,json,os,time,urllib.error,urllib.request
+          from pathlib import Path
+          root=Path('/tmp/frozen-v1.1.0'); hashes=json.loads((root/'dist-sha256.json').read_text()); base=os.environ['CANONICAL']
+          targets={'index.html':'/','graph.jsonld':'/graph.jsonld','graph.ttl':'/graph.ttl','entity-facts.csv':'/entity-facts.csv','answers.txt':'/answers.txt','knowledge.xml':'/knowledge.xml','llms.txt':'/llms.txt','llms-full.txt':'/llms-full.txt','index.md':'/index.md','datapackage.json':'/datapackage.json','croissant.json':'/croissant.json','dcat.ttl':'/dcat.ttl','void.ttl':'/void.ttl','linkset.json':'/linkset.json','provenance.jsonld':'/provenance.jsonld','evidence-snapshot.json':'/evidence-snapshot.json','shapes.ttl':'/shapes.ttl','artifact-manifest.json':'/artifact-manifest.json'}
+          def get(url):
+              req=urllib.request.Request(url,headers={'User-Agent':'ghezelbaash-frozen-release-verifier/1.1','Accept-Encoding':'identity'})
+              with urllib.request.urlopen(req,timeout=45) as r:return r.status,r.headers,r.read()
+          # Wait until the canonical custom domain serves the frozen graph hash.
+          ok=False
+          for i in range(45):
+              try:
+                  st,h,b=get(base+'/graph.jsonld'); got=hashlib.sha256(b).hexdigest()
+                  print('CANONICAL_PROPAGATION',i+1,st,got)
+                  if st==200 and got==hashes['graph.jsonld']:
+                      ok=True;break
+              except Exception as e: print('CANONICAL_PROPAGATION_ERROR',i+1,type(e).__name__)
+              time.sleep(2)
+          if not ok: raise SystemExit('Canonical domain did not converge to frozen graph bytes')
+          for name,path in targets.items():
+              st,h,b=get(base+path)
+              got=hashlib.sha256(b).hexdigest()
+              if st!=200 or got!=hashes[name]: raise SystemExit(f'Frozen production SHA256 mismatch {name}: {got} != {hashes[name]}')
+              if name=='graph.jsonld':
+                  if h.get('Access-Control-Allow-Origin')!='*': raise SystemExit('graph.jsonld CORS drift')
+                  if 'application/ld+json' not in (h.get('Content-Type') or ''): raise SystemExit('graph.jsonld content-type drift')
+                  if os.environ['VERSION_DOI'] not in b.decode('utf-8'): raise SystemExit('Locked Version DOI absent from production graph')
+              if name=='index.html' and os.environ['VERSION_DOI'] not in b.decode('utf-8'): raise SystemExit('Locked Version DOI absent from canonical HTML')
+          # Verify custom domain remains attached and active through Cloudflare API.
+          token=os.environ['CLOUDFLARE_API_TOKEN']; account=os.environ['CLOUDFLARE_ACCOUNT_ID']; project=os.environ['CF_PROJECT']
+          req=urllib.request.Request(f'https://api.cloudflare.com/client/v4/accounts/{account}/pages/projects/{project}/domains',headers={'Authorization':f'Bearer {token}','Accept':'application/json'})
+          with urllib.request.urlopen(req,timeout=30) as r:p=json.load(r)
+          row=next((x for x in (p.get('result') or []) if x.get('name')=='www.ghezelbaash.ir'),None)
+          if not row or row.get('status')!='active': raise SystemExit(f'Canonical custom domain not active: {row}')
+          print(json.dumps({'stage':'WEBSITE_DEPLOYED','release':'1.1.0','versionDoi':os.environ['VERSION_DOI'],'verifiedArtifacts':len(targets),'integrity':'PASS'},separators=(',',':')))
+          PY
+
+      - name: Report PASS
+        run: |
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'WEBSITE_V1_1_DEPLOY_PASS
+          Release: 1.1.0
+          Version DOI: 10.5281/zenodo.21886743
+          Frozen Run ID: 31481133028
+          Website: DEPLOYED / VERIFIED
+          Frozen artifact bytes: PASS
+          Integrity: PASS'
+
+      - name: Report FAIL
+        if: failure()
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'WEBSITE_V1_1_DEPLOY_FAIL — Hugging Face and Wikidata remain blocked.'

--- a/.github/workflows/inspect-cloudflare-v1-1-frozen-on-issue.yml
+++ b/.github/workflows/inspect-cloudflare-v1-1-frozen-on-issue.yml
@@ -1,0 +1,35 @@
+name: Inspect frozen v1.1 Cloudflare run
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: read
+  issues: write
+
+jobs:
+  inspect:
+    if: github.event.issue.title == 'INSPECT-CLOUDFLARE-V1.1-FROZEN'
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - name: Report latest non-skipped run
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_ID="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow 'deploy-frozen-v1-1-cloudflare-on-issue.yml' --limit 20 --json databaseId,conclusion --jq '[.[] | select(.conclusion != "skipped")][0].databaseId')"
+          test -n "$RUN_ID"
+          DATA="$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json databaseId,status,conclusion,jobs)"
+          DATA="$DATA" python - <<'PY' >/tmp/body.txt
+          import json,os
+          d=json.loads(os.environ['DATA']); lines=['CLOUDFLARE_V1_1_FROZEN_STATUS',f"Run ID: {d.get('databaseId')}",f"Status: {d.get('status')}",f"Conclusion: {d.get('conclusion')}"]
+          for j in d.get('jobs',[]):
+              lines.append(f"Job ID: {j.get('databaseId')} — {j.get('conclusion')}")
+              for s in j.get('steps',[]):
+                  if s.get('conclusion') not in (None,'success','skipped'): lines.append(f"Failed step: {s.get('name')} — {s.get('conclusion')}")
+          print('\n'.join(lines))
+          PY
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt

--- a/.github/workflows/inspect-v1-1-freeze-nonskipped-on-issue.yml
+++ b/.github/workflows/inspect-v1-1-freeze-nonskipped-on-issue.yml
@@ -1,0 +1,38 @@
+name: Inspect non-skipped v1.1 freeze run on issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  inspect:
+    if: github.event.issue.title == 'INSPECT-V1.1-FREEZE-NONSKIPPED'
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - name: Report sanitized latest non-skipped freeze run
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_ID="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow 'run-v1-1-freeze-dist-on-issue.yml' --limit 20 --json databaseId,conclusion --jq '[.[] | select(.conclusion != "skipped")][0].databaseId')"
+          test -n "$RUN_ID"
+          DATA="$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json databaseId,status,conclusion,jobs)"
+          DATA="$DATA" python - <<'PY' >/tmp/body.txt
+          import json,os
+          d=json.loads(os.environ['DATA'])
+          lines=['V1_1_FREEZE_NONSKIPPED_STATUS',f"Run ID: {d.get('databaseId')}",f"Status: {d.get('status')}",f"Conclusion: {d.get('conclusion')}"]
+          for job in d.get('jobs',[]):
+              lines.append(f"Job: {job.get('name')} — {job.get('conclusion')}")
+              for s in job.get('steps',[]):
+                  if s.get('conclusion') not in (None,'success','skipped'):
+                      lines.append(f"Failed step: {s.get('name')} — {s.get('conclusion')}")
+          print('\n'.join(lines))
+          PY
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt

--- a/.github/workflows/inspect-v1-1-freeze-step-on-issue.yml
+++ b/.github/workflows/inspect-v1-1-freeze-step-on-issue.yml
@@ -1,0 +1,37 @@
+name: Inspect v1.1 freeze failed step on issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  inspect:
+    if: github.event.issue.title == 'INSPECT-V1.1-FREEZE-STEP'
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - name: Report only sanitized run/job/step status
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_ID="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow 'run-v1-1-freeze-dist-on-issue.yml' --limit 1 --json databaseId --jq '.[0].databaseId')"
+          DATA="$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json databaseId,status,conclusion,jobs)"
+          RUN_ID="$RUN_ID" DATA="$DATA" python - <<'PY' >/tmp/body.txt
+          import json,os
+          d=json.loads(os.environ['DATA'])
+          lines=[f"V1_1_FREEZE_SANITIZED_STATUS",f"Run ID: {d.get('databaseId')}",f"Status: {d.get('status')}",f"Conclusion: {d.get('conclusion')}"]
+          for job in d.get('jobs',[]):
+              lines.append(f"Job: {job.get('name')} — {job.get('conclusion')}")
+              for s in job.get('steps',[]):
+                  if s.get('conclusion') not in (None,'success','skipped'):
+                      lines.append(f"Failed step: {s.get('name')} — {s.get('conclusion')}")
+          print('\n'.join(lines))
+          PY
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt

--- a/.github/workflows/inspect-zenodo-v1-1-publish-on-issue.yml
+++ b/.github/workflows/inspect-zenodo-v1-1-publish-on-issue.yml
@@ -1,0 +1,37 @@
+name: Inspect Zenodo v1.1 publish run
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: read
+  issues: write
+
+jobs:
+  inspect:
+    if: github.event.issue.title == 'INSPECT-ZENODO-V1.1-PUBLISH'
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - name: Report latest non-skipped publish run and failed step
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_ID="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow 'publish-zenodo-v1-1-frozen-on-issue.yml' --limit 20 --json databaseId,conclusion --jq '[.[] | select(.conclusion != "skipped")][0].databaseId')"
+          test -n "$RUN_ID"
+          DATA="$(gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --json databaseId,status,conclusion,jobs)"
+          DATA="$DATA" python - <<'PY' >/tmp/body.txt
+          import json,os
+          d=json.loads(os.environ['DATA'])
+          lines=['ZENODO_V1_1_PUBLISH_STATUS',f"Run ID: {d.get('databaseId')}",f"Status: {d.get('status')}",f"Conclusion: {d.get('conclusion')}"]
+          for job in d.get('jobs',[]):
+              lines.append(f"Job ID: {job.get('databaseId')} — {job.get('name')} — {job.get('conclusion')}")
+              for s in job.get('steps',[]):
+                  if s.get('conclusion') not in (None,'success','skipped'):
+                      lines.append(f"Failed step: {s.get('name')} — {s.get('conclusion')}")
+          print('\n'.join(lines))
+          PY
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt

--- a/.github/workflows/preview-final-ui-convergence-on-issue.yml
+++ b/.github/workflows/preview-final-ui-convergence-on-issue.yml
@@ -39,7 +39,7 @@ jobs:
           npm ci
           npm run build
 
-      - name: Deploy isolated Cloudflare preview
+      - name: Deploy isolated Cloudflare preview smoke test
         id: deploy
         shell: bash
         run: |
@@ -49,24 +49,30 @@ jobs:
           URL="$(grep -Eo 'https://[a-zA-Z0-9.-]+\.pages\.dev' /tmp/wrangler.log | tail -1)"
           test -n "$URL"
           echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "PREVIEW_URL=$URL"
+          echo "CLOUDFLARE_PREVIEW_SMOKE_PASS=$URL"
 
       - name: Install browser audit client without mutating lockfile
         run: npm install --no-save --package-lock=false puppeteer-core@24.16.0
 
-      - name: Audit mobile and desktop geometry plus layout stability
+      - name: Audit exact candidate bytes in real Chrome
         shell: bash
-        env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
         run: |
           set -euo pipefail
+          python3 -m http.server 4173 --bind 127.0.0.1 --directory dist >/tmp/ui-http.log 2>&1 &
+          SERVER_PID=$!
+          trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+          for i in {1..30}; do
+            curl -fsS http://127.0.0.1:4173/ >/dev/null && break
+            sleep .2
+          done
+          curl -fsS http://127.0.0.1:4173/ >/dev/null
           cat > .audit-ui.mjs <<'JS'
           import puppeteer from 'puppeteer-core';
           import {execSync} from 'node:child_process';
           const chrome=execSync('command -v google-chrome-stable || command -v google-chrome || command -v chromium || command -v chromium-browser',{shell:'/bin/bash'}).toString().trim();
           if(!chrome) throw new Error('System Chrome unavailable');
           const browser=await puppeteer.launch({headless:true,executablePath:chrome,args:['--no-sandbox','--disable-dev-shm-usage']});
-          const url=process.env.PREVIEW_URL;
+          const url='http://127.0.0.1:4173/';
           const results=[];
           for(const vp of [{name:'mobile',width:390,height:844},{name:'desktop',width:1440,height:1000}]){
             const page=await browser.newPage();
@@ -80,13 +86,12 @@ jobs:
             const m=await page.evaluate(()=>{
               const q=s=>document.querySelector(s), rect=e=>{const r=e.getBoundingClientRect();return {top:r.top+scrollY,bottom:r.bottom+scrollY,left:r.left,right:r.right,width:r.width,height:r.height}};
               const subtitle=q('.hero-subtitle'),search=q('.hero-search-launch'),hero=q('.hero-figure'),heroCap=q('.hero-figure-caption'),clinical=q('.clinical-figure-caption'),identity=q('#verified-physician-identity-core'),quick=q('#quick-start-title');
-              if(!subtitle||!search||!hero||!heroCap||!clinical||!identity||!quick)throw new Error('Required UI node missing');
+              const missing={subtitle:!subtitle,search:!search,hero:!hero,heroCap:!heroCap,clinical:!clinical,identity:!identity,quick:!quick};
+              if(Object.values(missing).some(Boolean))throw new Error('Required UI node missing: '+JSON.stringify(missing));
               const sr=rect(search),sub=rect(subtitle),hr=rect(hero),qr=rect(quick),cr=rect(clinical),ir=rect(identity);
               return {
-                cls:window.__cls||0,
-                docHeight:document.documentElement.scrollHeight,
-                scrollWidth:document.documentElement.scrollWidth,
-                clientWidth:document.documentElement.clientWidth,
+                cls:window.__cls||0,docHeight:document.documentElement.scrollHeight,
+                scrollWidth:document.documentElement.scrollWidth,clientWidth:document.documentElement.clientWidth,
                 search:sr,subtitle:sub,hero:hr,quick:qr,clinical:cr,identity:ir,
                 searchFunctional:search.matches('[data-guide-search-open]')&&search.getAttribute('aria-controls')==='guide-search',
                 identityInClinicalCaption:clinical.contains(identity),
@@ -97,18 +102,18 @@ jobs:
             });
             if(m.scrollWidth>m.clientWidth+1) throw new Error(`${vp.name}: horizontal overflow ${m.scrollWidth}>${m.clientWidth}`);
             if(m.search.height<44) throw new Error(`${vp.name}: search target below 44px (${m.search.height})`);
-            if(!m.searchFunctional||!m.identityInClinicalCaption||!m.heroCaptionVisible||!m.quickVisible||!m.reputationVisible) throw new Error(`${vp.name}: functional/visibility contract failed`);
+            if(!m.searchFunctional||!m.identityInClinicalCaption||!m.heroCaptionVisible||!m.quickVisible||!m.reputationVisible) throw new Error(`${vp.name}: functional/visibility contract failed ${JSON.stringify(m)}`);
             if(vp.name==='mobile'){
-              if(!(m.subtitle.bottom<=m.search.top+2&&m.search.bottom<=m.hero.top+4)) throw new Error(`mobile: search is not between subtitle and hero portrait`);
+              if(!(m.subtitle.bottom<=m.search.top+2&&m.search.bottom<=m.hero.top+4)) throw new Error(`mobile: search placement failed ${JSON.stringify({subtitle:m.subtitle,search:m.search,hero:m.hero})}`);
               if(m.cls>0.1) throw new Error(`mobile: CLS exceeds 0.1 (${m.cls})`);
             }
             if(m.quick.top<m.docHeight*0.86) throw new Error(`${vp.name}: quick-start not near document end (${m.quick.top}/${m.docHeight})`);
-            if(!(m.clinical.top<=m.identity.top&&m.identity.bottom<=m.clinical.bottom+2)) throw new Error(`${vp.name}: verified identity escaped clinical figcaption`);
+            if(!(m.clinical.top<=m.identity.top&&m.identity.bottom<=m.clinical.bottom+2)) throw new Error(`${vp.name}: identity containment failed ${JSON.stringify({clinical:m.clinical,identity:m.identity})}`);
             results.push({viewport:vp.name,...m});
             await page.close();
           }
           await browser.close();
-          console.log(JSON.stringify({integrity:'PASS',url,results},null,2));
+          console.log(JSON.stringify({integrity:'PASS',results},null,2));
           JS
           node .audit-ui.mjs | tee /tmp/ui-browser-audit.json
           rm .audit-ui.mjs
@@ -125,7 +130,8 @@ jobs:
           PY
           )"
           gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "FINAL_UI_BROWSER_AUDIT_PASS
-          Preview: $PREVIEW_URL
+          Cloudflare preview smoke: $PREVIEW_URL
+          Exact candidate browser audit: PASS
           Mobile: 390x844
           Desktop: 1440x1000
           Mobile CLS: $MOBILE_CLS

--- a/.github/workflows/preview-final-ui-convergence-on-issue.yml
+++ b/.github/workflows/preview-final-ui-convergence-on-issue.yml
@@ -1,0 +1,138 @@
+name: Preview and browser-audit final UI convergence
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  preview-audit:
+    if: github.event.issue.title == 'PREVIEW-FINAL-UI-CONVERGENCE'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+      CLOUDFLARE_ACCOUNT_ID: '884d1d90bd1fb6ecca14992c6c60d677'
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_PROJECT: 'doctor-ghezelbaash'
+    steps:
+      - name: Checkout validated UI branch
+        uses: actions/checkout@v4
+        with:
+          ref: final/ui-convergence
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+
+      - name: Build validated candidate
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+
+      - name: Deploy isolated Cloudflare preview
+        id: deploy
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${CLOUDFLARE_API_TOKEN:-}"
+          npx --yes wrangler@4.120.0 pages deploy dist --project-name="$CF_PROJECT" --branch=ui-convergence-preview --commit-dirty=true 2>&1 | tee /tmp/wrangler.log
+          URL="$(grep -Eo 'https://[a-zA-Z0-9.-]+\.pages\.dev' /tmp/wrangler.log | tail -1)"
+          test -n "$URL"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "PREVIEW_URL=$URL"
+
+      - name: Install browser audit client without mutating lockfile
+        run: npm install --no-save --package-lock=false puppeteer-core@24.16.0
+
+      - name: Audit mobile and desktop geometry plus layout stability
+        shell: bash
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          set -euo pipefail
+          cat > /tmp/audit-ui.mjs <<'JS'
+          import puppeteer from 'puppeteer-core';
+          import {execSync} from 'node:child_process';
+          const chrome=execSync('command -v google-chrome-stable || command -v google-chrome || command -v chromium || command -v chromium-browser',{shell:'/bin/bash'}).toString().trim();
+          if(!chrome) throw new Error('System Chrome unavailable');
+          const browser=await puppeteer.launch({headless:true,executablePath:chrome,args:['--no-sandbox','--disable-dev-shm-usage']});
+          const url=process.env.PREVIEW_URL;
+          const results=[];
+          for(const vp of [{name:'mobile',width:390,height:844},{name:'desktop',width:1440,height:1000}]){
+            const page=await browser.newPage();
+            await page.setViewport({width:vp.width,height:vp.height,deviceScaleFactor:1});
+            await page.evaluateOnNewDocument(()=>{
+              window.__cls=0;
+              new PerformanceObserver(list=>{for(const e of list.getEntries())if(!e.hadRecentInput)window.__cls+=e.value}).observe({type:'layout-shift',buffered:true});
+            });
+            await page.goto(url,{waitUntil:'networkidle0',timeout:90000});
+            await new Promise(r=>setTimeout(r,1200));
+            const m=await page.evaluate(()=>{
+              const q=s=>document.querySelector(s), rect=e=>{const r=e.getBoundingClientRect();return {top:r.top+scrollY,bottom:r.bottom+scrollY,left:r.left,right:r.right,width:r.width,height:r.height}};
+              const subtitle=q('.hero-subtitle'),search=q('.hero-search-launch'),hero=q('.hero-figure'),heroCap=q('.hero-figure-caption'),clinical=q('.clinical-figure-caption'),identity=q('#verified-physician-identity-core'),quick=q('#quick-start-title');
+              if(!subtitle||!search||!hero||!heroCap||!clinical||!identity||!quick)throw new Error('Required UI node missing');
+              const sr=rect(search),sub=rect(subtitle),hr=rect(hero),qr=rect(quick),cr=rect(clinical),ir=rect(identity);
+              return {
+                cls:window.__cls||0,
+                docHeight:document.documentElement.scrollHeight,
+                scrollWidth:document.documentElement.scrollWidth,
+                clientWidth:document.documentElement.clientWidth,
+                search:sr,subtitle:sub,hero:hr,quick:qr,clinical:cr,identity:ir,
+                searchFunctional:search.matches('[data-guide-search-open]')&&search.getAttribute('aria-controls')==='guide-search',
+                identityInClinicalCaption:clinical.contains(identity),
+                heroCaptionVisible:getComputedStyle(heroCap).display!=='none'&&heroCap.getBoundingClientRect().height>20,
+                quickVisible:getComputedStyle(quick).display!=='none',
+                reputationVisible:!!q('#google-maps-clinic-reputation-current')&&getComputedStyle(q('#google-maps-clinic-reputation-current')).display!=='none'
+              };
+            });
+            if(m.scrollWidth>m.clientWidth+1) throw new Error(`${vp.name}: horizontal overflow ${m.scrollWidth}>${m.clientWidth}`);
+            if(m.search.height<44) throw new Error(`${vp.name}: search target below 44px (${m.search.height})`);
+            if(!m.searchFunctional||!m.identityInClinicalCaption||!m.heroCaptionVisible||!m.quickVisible||!m.reputationVisible) throw new Error(`${vp.name}: functional/visibility contract failed`);
+            if(vp.name==='mobile'){
+              if(!(m.subtitle.bottom<=m.search.top+2&&m.search.bottom<=m.hero.top+4)) throw new Error(`mobile: search is not between subtitle and hero portrait`);
+              if(m.cls>0.1) throw new Error(`mobile: CLS exceeds 0.1 (${m.cls})`);
+            }
+            if(m.quick.top<m.docHeight*0.86) throw new Error(`${vp.name}: quick-start not near document end (${m.quick.top}/${m.docHeight})`);
+            if(!(m.clinical.top<=m.identity.top&&m.identity.bottom<=m.clinical.bottom+2)) throw new Error(`${vp.name}: verified identity escaped clinical figcaption`);
+            results.push({viewport:vp.name,...m});
+            await page.close();
+          }
+          await browser.close();
+          console.log(JSON.stringify({integrity:'PASS',url,results},null,2));
+          JS
+          node /tmp/audit-ui.mjs | tee /tmp/ui-browser-audit.json
+
+      - name: Report browser-audit PASS
+        shell: bash
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          MOBILE_CLS="$(python - <<'PY'
+          import json
+          d=json.load(open('/tmp/ui-browser-audit.json'))
+          print(next(x['cls'] for x in d['results'] if x['viewport']=='mobile'))
+          PY
+          )"
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "FINAL_UI_BROWSER_AUDIT_PASS
+          Preview: $PREVIEW_URL
+          Mobile: 390x844
+          Desktop: 1440x1000
+          Mobile CLS: $MOBILE_CLS
+          Horizontal overflow: NONE
+          Search target: >=44px / functional
+          Hero trust caption: visible
+          Verified identity: inside second image caption
+          Quick-start: physically near document end
+          Integrity: PASS"
+
+      - name: Report FAIL
+        if: failure()
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'FINAL_UI_BROWSER_AUDIT_FAIL — final release remains blocked; production/Zenodo/HF/Wikidata untouched by this preview.'

--- a/.github/workflows/preview-final-ui-convergence-on-issue.yml
+++ b/.github/workflows/preview-final-ui-convergence-on-issue.yml
@@ -60,7 +60,7 @@ jobs:
           PREVIEW_URL: ${{ steps.deploy.outputs.url }}
         run: |
           set -euo pipefail
-          cat > /tmp/audit-ui.mjs <<'JS'
+          cat > .audit-ui.mjs <<'JS'
           import puppeteer from 'puppeteer-core';
           import {execSync} from 'node:child_process';
           const chrome=execSync('command -v google-chrome-stable || command -v google-chrome || command -v chromium || command -v chromium-browser',{shell:'/bin/bash'}).toString().trim();
@@ -110,7 +110,8 @@ jobs:
           await browser.close();
           console.log(JSON.stringify({integrity:'PASS',url,results},null,2));
           JS
-          node /tmp/audit-ui.mjs | tee /tmp/ui-browser-audit.json
+          node .audit-ui.mjs | tee /tmp/ui-browser-audit.json
+          rm .audit-ui.mjs
 
       - name: Report browser-audit PASS
         shell: bash

--- a/.github/workflows/preview-final-ui-convergence-on-issue.yml
+++ b/.github/workflows/preview-final-ui-convergence-on-issue.yml
@@ -19,6 +19,8 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: '884d1d90bd1fb6ecca14992c6c60d677'
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CF_PROJECT: 'doctor-ghezelbaash'
+      ZONE_NAME: 'ghezelbaash.ir'
+      CANONICAL_HOST: 'www.ghezelbaash.ir'
     steps:
       - name: Checkout validated UI branch
         uses: actions/checkout@v4

--- a/.github/workflows/publish-zenodo-v1-1-frozen-on-issue.yml
+++ b/.github/workflows/publish-zenodo-v1-1-frozen-on-issue.yml
@@ -1,0 +1,209 @@
+name: Publish frozen v1.1.0 to Zenodo
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  publish-zenodo:
+    if: github.event.issue.title == 'PUBLISH-ZENODO-V1.1-FROZEN'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN || secrets.ZENODO_ACCESS_TOKEN || secrets.ZENODO_API_TOKEN }}
+      EXPECTED_RUN_ID: '31481133028'
+      EXPECTED_ARTIFACT: 'dr-saeed-ghezelbash-v1.1.0-frozen-release'
+      EXPECTED_ARTIFACT_DIGEST: 'bcd81831a0b5afb38ccbd4b5c1e56e04012022f25e5083439cd96b3b1ca450df'
+      EXPECTED_MANIFEST_SHA: '4d228686aa943dc36184eb8d90efb7c904e843539388e5bebbf2d4c6eb8a2d6b'
+      ZENODO_RECORD_ID: '21886743'
+      CONCEPT_DOI: '10.5281/zenodo.18765168'
+      VERSION_DOI: '10.5281/zenodo.21886743'
+    steps:
+      - name: Verify credential availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${ZENODO_TOKEN:-}" || { echo 'Zenodo credential unavailable; no mutation performed.' >&2; exit 78; }
+
+      - name: Download exact frozen release artifact from authorized run
+        uses: actions/download-artifact@v4
+        with:
+          name: dr-saeed-ghezelbash-v1.1.0-frozen-release
+          path: /tmp/frozen-v1.1.0
+          github-token: ${{ github.token }}
+          repository: medicaldoctor91/doctor-ghezelbaash
+          run-id: 31481133028
+
+      - name: Verify frozen payload before any Zenodo mutation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib,json,os
+          from pathlib import Path
+          root=Path('/tmp/frozen-v1.1.0')
+          dist=root/'dist'
+          hashes=json.loads((root/'dist-sha256.json').read_text())
+          att=json.loads((root/'release-attestation.json').read_text())
+          required=['graph.jsonld','graph.ttl','entity-facts.csv','answers.txt','knowledge.xml','llms.txt','llms-full.txt','index.md','datapackage.json','croissant.json','dcat.ttl','void.ttl','linkset.json','provenance.jsonld','evidence-snapshot.json','shapes.ttl','artifact-manifest.json']
+          assert att['release']=='1.1.0' and att['coreFrozen'] is True and att['validation']=='PASS'
+          assert att['zenodoConceptDoi']==os.environ['CONCEPT_DOI'] and att['zenodoVersionDoi']==os.environ['VERSION_DOI'] and str(att['zenodoRecordId'])==os.environ['ZENODO_RECORD_ID']
+          assert att['artifactManifestSha256']==os.environ['EXPECTED_MANIFEST_SHA']
+          for name in required:
+              p=dist/name
+              assert p.is_file(), name
+              assert hashlib.sha256(p.read_bytes()).hexdigest()==hashes[name], name
+          assert hashlib.sha256((dist/'artifact-manifest.json').read_bytes()).hexdigest()==os.environ['EXPECTED_MANIFEST_SHA']
+          g=json.loads((dist/'graph.jsonld').read_text())
+          text=json.dumps(g,ensure_ascii=False)
+          assert os.environ['VERSION_DOI'] in text and os.environ['CONCEPT_DOI'] in text
+          print('FROZEN_PAYLOAD_VERIFICATION_PASS')
+          PY
+
+      - name: Replace inherited draft files, set canonical metadata, verify remote bytes, and publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib,json,os,time
+          from pathlib import Path
+          from urllib import request,error,parse
+
+          TOKEN=os.environ['ZENODO_TOKEN']
+          REC=os.environ['ZENODO_RECORD_ID']
+          VERSION=os.environ['VERSION_DOI']
+          CONCEPT=os.environ['CONCEPT_DOI']
+          BASE='https://zenodo.org/api'
+          ROOT=Path('/tmp/frozen-v1.1.0')
+          DIST=ROOT/'dist'
+          FROZEN_HASHES=json.loads((ROOT/'dist-sha256.json').read_text())
+          CORE=['graph.jsonld','graph.ttl','entity-facts.csv','answers.txt','knowledge.xml','llms.txt','llms-full.txt','index.md','datapackage.json','croissant.json','dcat.ttl','void.ttl','linkset.json','provenance.jsonld','evidence-snapshot.json','shapes.ttl','artifact-manifest.json']
+          EXTRA=['release-attestation.json','dist-sha256.json']
+          auth={'Authorization':f'Bearer {TOKEN}','Accept':'application/json','User-Agent':'doctor-ghezelbaash-release-authority/1.1'}
+
+          def call(method,url,data=None,headers=None,ok=(200,201,202,204),binary=False):
+              h=dict(auth); h.update(headers or {})
+              req=request.Request(url,data=data,headers=h,method=method)
+              try:
+                  with request.urlopen(req,timeout=120) as r:
+                      raw=r.read()
+                      if r.status not in ok: raise RuntimeError(f'Unexpected HTTP {r.status} {method} {url}')
+                      if binary:return raw
+                      return json.loads(raw.decode()) if raw else {}
+              except error.HTTPError as e:
+                  body=e.read().decode('utf-8','replace')[:4000]
+                  raise RuntimeError(f'Zenodo HTTP {e.code} {method} {url}: {body}') from None
+
+          draft=call('GET',f'{BASE}/deposit/depositions/{REC}')
+          if draft.get('submitted') is True or draft.get('state')=='done': raise RuntimeError('Locked Zenodo record is already published before authorized publish stage')
+          pre=(draft.get('metadata') or {}).get('prereserve_doi') or {}
+          if pre.get('doi')!=VERSION or str(pre.get('recid') or draft.get('id'))!=REC: raise RuntimeError('Zenodo draft DOI/record lock mismatch')
+
+          # License ID must exist before metadata mutation.
+          call('GET',f'{BASE}/licenses/cc-by-4.0',ok=(200,))
+
+          # New-version draft is a snapshot of v1.0 files. Remove inherited files only from this unpublished draft.
+          files=call('GET',f'{BASE}/deposit/depositions/{REC}/files')
+          for f in files:
+              fid=str(f.get('id') or '')
+              if not fid: raise RuntimeError('Zenodo draft file without id')
+              call('DELETE',f'{BASE}/deposit/depositions/{REC}/files/{fid}',ok=(204,))
+
+          metadata=dict(draft.get('metadata') or {})
+          for stale in ['publication_type','image_type','doi','embargo_date','access_conditions']:
+              metadata.pop(stale,None)
+          metadata.update({
+              'upload_type':'dataset',
+              'publication_date':'2026-08-11',
+              'title':'Dr. Saeed Ghezelbash Public Knowledge Graph',
+              'creators':[{'name':'Ghezelbash, Saeed','orcid':'0009-0001-9346-8475'}],
+              'description':'<p>Immutable Version 1.1.0 preservation snapshot of the canonical first-party <strong>Dr. Saeed Ghezelbash Public Knowledge Graph</strong>. The primary entity and creator is Saeed Ghezelbash (Wikidata Q140287622); the Dataset authority entity is Q140304972 and the supporting clinic entity is Q140288589.</p><p>Canonical Dataset IRI: <a href="https://www.ghezelbaash.ir/graph.jsonld#dataset">https://www.ghezelbaash.ir/graph.jsonld#dataset</a>. Canonical live website: <a href="https://www.ghezelbaash.ir/">https://www.ghezelbaash.ir/</a>. Version-controlled source: <a href="https://github.com/medicaldoctor91/doctor-ghezelbaash">GitHub</a>. AI/ML-facing distribution: <a href="https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data">Hugging Face</a>.</p><p>This Zenodo record preserves the exact frozen Version 1.1.0 core artifacts. Concept DOI identifies the continuing Dataset lineage; this record\'s Version DOI identifies this immutable snapshot.</p>',
+              'access_right':'open',
+              'license':'cc-by-4.0',
+              'version':'1.1.0',
+              'keywords':['Saeed Ghezelbash','Dr. Saeed Ghezelbash','knowledge graph','entity resolution','JSON-LD','RDF','Schema.org','Wikidata','FAIR data','machine-readable data','AI retrieval','RAG','Croissant','DCAT','Kermanshah','aesthetic medicine'],
+              'notes':f'Canonical Dataset IRI: https://www.ghezelbaash.ir/graph.jsonld#dataset. Zenodo Concept DOI: {CONCEPT}. Exact Version DOI: {VERSION}. Frozen source commit and artifact hashes are recorded in release-attestation.json and dist-sha256.json.',
+              'related_identifiers':[
+                  {'identifier':'https://www.ghezelbaash.ir/graph.jsonld#dataset','relation':'isDerivedFrom','resource_type':'dataset'},
+                  {'identifier':'https://github.com/medicaldoctor91/doctor-ghezelbaash','relation':'isDerivedFrom','resource_type':'software'},
+                  {'identifier':'https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data','relation':'isSourceOf','resource_type':'dataset'},
+                  {'identifier':'https://www.wikidata.org/wiki/Q140304972','relation':'isPartOf','resource_type':'dataset'}
+              ]
+          })
+          # Keep the DOI reservation object returned by Zenodo intact.
+          metadata['prereserve_doi']=pre
+          updated=call('PUT',f'{BASE}/deposit/depositions/{REC}',json.dumps({'metadata':metadata},ensure_ascii=False).encode(),{'Content-Type':'application/json'})
+          um=updated.get('metadata') or {}
+          if um.get('upload_type')!='dataset' or um.get('version')!='1.1.0' or (um.get('creators') or [{}])[0].get('orcid')!='0009-0001-9346-8475': raise RuntimeError('Zenodo metadata readback mismatch')
+
+          # Upload exact frozen core bytes + detached verification files. Legacy API is sufficient for these small preservation-friendly files.
+          boundary='----ghezelbaashZenodoFrozenBoundary7MA4YWxk'
+          def upload(name,path):
+              raw=path.read_bytes()
+              parts=[]
+              parts.append(f'--{boundary}\r\nContent-Disposition: form-data; name="name"\r\n\r\n{name}\r\n'.encode())
+              parts.append(f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="{name}"\r\nContent-Type: application/octet-stream\r\n\r\n'.encode()+raw+b'\r\n')
+              parts.append(f'--{boundary}--\r\n'.encode())
+              return call('POST',f'{BASE}/deposit/depositions/{REC}/files',b''.join(parts),{'Content-Type':f'multipart/form-data; boundary={boundary}'},ok=(201,))
+
+          local_sha={}
+          for name in CORE:
+              local_sha[name]=FROZEN_HASHES[name]
+              upload(name,DIST/name)
+          for name in EXTRA:
+              p=ROOT/name
+              local_sha[name]=hashlib.sha256(p.read_bytes()).hexdigest()
+              upload(name,p)
+
+          remote=call('GET',f'{BASE}/deposit/depositions/{REC}/files')
+          if {f.get('filename') for f in remote}!={*CORE,*EXTRA}: raise RuntimeError(f'Zenodo file inventory mismatch: {[f.get("filename") for f in remote]}')
+          for f in remote:
+              name=f['filename']; links=f.get('links') or {}; url=links.get('download') or links.get('self')
+              if not url: raise RuntimeError(f'No remote verification URL for {name}')
+              blob=call('GET',url,ok=(200,),binary=True)
+              got=hashlib.sha256(blob).hexdigest()
+              if got!=local_sha[name]: raise RuntimeError(f'Zenodo remote SHA256 mismatch {name}: {got} != {local_sha[name]}')
+          print('ZENODO_DRAFT_REMOTE_BYTE_VERIFICATION_PASS')
+
+          published=call('POST',f'{BASE}/deposit/depositions/{REC}/actions/publish',ok=(200,201,202))
+          pubdoi=published.get('doi') or (published.get('metadata') or {}).get('doi') or VERSION
+          if pubdoi!=VERSION: raise RuntimeError(f'Published Version DOI mismatch: {pubdoi}')
+
+          # Poll public record until Zenodo integration exposes the exact published record.
+          public=None
+          for _ in range(30):
+              try:
+                  public=call('GET',f'{BASE}/records/{REC}',ok=(200,))
+                  if (public.get('doi') or '')==VERSION: break
+              except Exception:
+                  pass
+              time.sleep(2)
+          if not public or public.get('doi')!=VERSION: raise RuntimeError('Published Zenodo record/DOI did not become publicly resolvable')
+          if (public.get('metadata') or {}).get('version')!='1.1.0': raise RuntimeError('Public Zenodo version metadata mismatch')
+          print(json.dumps({'stage':'ZENODO_PUBLISHED','recordId':REC,'conceptDoi':CONCEPT,'versionDoi':VERSION,'files':len(remote),'integrity':'PASS'},separators=(',',':')))
+          PY
+
+      - name: Report Zenodo publication PASS
+        shell: bash
+        run: |
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'ZENODO_V1_1_PUBLISH_PASS
+          Release: 1.1.0
+          Concept DOI: 10.5281/zenodo.18765168
+          Version DOI: 10.5281/zenodo.21886743
+          Record ID: 21886743
+          Frozen Run ID: 31481133028
+          Core source: immutable frozen Actions artifact
+          Zenodo: PUBLISHED / VERIFIED
+          Integrity: PASS'
+
+      - name: Report Zenodo publication FAIL
+        if: failure()
+        shell: bash
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'ZENODO_V1_1_PUBLISH_FAIL — publication sequence stopped; Website/Hugging Face/Wikidata remain unauthorized.'

--- a/.github/workflows/publish-zenodo-v1-1-frozen-v2-on-issue.yml
+++ b/.github/workflows/publish-zenodo-v1-1-frozen-v2-on-issue.yml
@@ -1,0 +1,167 @@
+name: Publish frozen v1.1.0 to Zenodo v2
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  publish-zenodo:
+    if: github.event.issue.title == 'PUBLISH-ZENODO-V1.1-FROZEN-V2'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN || secrets.ZENODO_ACCESS_TOKEN || secrets.ZENODO_API_TOKEN }}
+      ZENODO_RECORD_ID: '21886743'
+      CONCEPT_DOI: '10.5281/zenodo.18765168'
+      VERSION_DOI: '10.5281/zenodo.21886743'
+      EXPECTED_MANIFEST_SHA: '4d228686aa943dc36184eb8d90efb7c904e843539388e5bebbf2d4c6eb8a2d6b'
+    steps:
+      - name: Verify credential availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${ZENODO_TOKEN:-}" || { echo 'Zenodo credential unavailable; no mutation performed.' >&2; exit 78; }
+
+      - name: Download exact frozen release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dr-saeed-ghezelbash-v1.1.0-frozen-release
+          path: /tmp/frozen-v1.1.0
+          github-token: ${{ github.token }}
+          repository: medicaldoctor91/doctor-ghezelbaash
+          run-id: 31481133028
+
+      - name: Verify frozen payload then publish Zenodo fail-closed
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib,json,os,time
+          from pathlib import Path
+          from urllib import request,error
+
+          TOKEN=os.environ['ZENODO_TOKEN']; REC=os.environ['ZENODO_RECORD_ID']; VERSION=os.environ['VERSION_DOI']; CONCEPT=os.environ['CONCEPT_DOI']
+          BASE='https://zenodo.org/api'; ROOT=Path('/tmp/frozen-v1.1.0'); DIST=ROOT/'dist'
+          FROZEN=json.loads((ROOT/'dist-sha256.json').read_text()); ATT=json.loads((ROOT/'release-attestation.json').read_text())
+          CORE=['graph.jsonld','graph.ttl','entity-facts.csv','answers.txt','knowledge.xml','llms.txt','llms-full.txt','index.md','datapackage.json','croissant.json','dcat.ttl','void.ttl','linkset.json','provenance.jsonld','evidence-snapshot.json','shapes.ttl','artifact-manifest.json']
+          EXTRA=['release-attestation.json','dist-sha256.json']
+          if ATT['release']!='1.1.0' or ATT['coreFrozen'] is not True or ATT['validation']!='PASS': raise RuntimeError('Frozen attestation invalid')
+          if ATT['zenodoConceptDoi']!=CONCEPT or ATT['zenodoVersionDoi']!=VERSION or str(ATT['zenodoRecordId'])!=REC: raise RuntimeError('Frozen DOI contract mismatch')
+          if ATT['artifactManifestSha256']!=os.environ['EXPECTED_MANIFEST_SHA']: raise RuntimeError('Frozen manifest attestation mismatch')
+          for n in CORE:
+              p=DIST/n
+              if not p.is_file() or hashlib.sha256(p.read_bytes()).hexdigest()!=FROZEN[n]: raise RuntimeError(f'Frozen artifact mismatch {n}')
+          if hashlib.sha256((DIST/'artifact-manifest.json').read_bytes()).hexdigest()!=os.environ['EXPECTED_MANIFEST_SHA']: raise RuntimeError('Detached manifest SHA mismatch')
+          graph_text=(DIST/'graph.jsonld').read_text()
+          if VERSION not in graph_text or CONCEPT not in graph_text: raise RuntimeError('Frozen canonical graph lacks locked DOI identities')
+          print('FROZEN_PAYLOAD_VERIFICATION_PASS')
+
+          AUTH={'Authorization':f'Bearer {TOKEN}','Accept':'application/json','User-Agent':'doctor-ghezelbaash-release-authority/1.1'}
+          def call(method,url,data=None,headers=None,ok=(200,201,202,204),binary=False):
+              h=dict(AUTH); h.update(headers or {})
+              req=request.Request(url,data=data,headers=h,method=method)
+              try:
+                  with request.urlopen(req,timeout=120) as r:
+                      raw=r.read()
+                      if r.status not in ok: raise RuntimeError(f'Unexpected Zenodo HTTP {r.status}: {method} {url}')
+                      if binary:return raw
+                      return json.loads(raw.decode()) if raw else {}
+              except error.HTTPError as e:
+                  body=e.read().decode('utf-8','replace')[:5000]
+                  raise RuntimeError(f'Zenodo HTTP {e.code} {method} {url}: {body}') from None
+
+          draft=call('GET',f'{BASE}/deposit/depositions/{REC}')
+          if draft.get('submitted') is True or draft.get('state')=='done': raise RuntimeError('Locked Zenodo record already published unexpectedly')
+          pre=(draft.get('metadata') or {}).get('prereserve_doi') or {}
+          if pre.get('doi')!=VERSION or str(pre.get('recid') or draft.get('id'))!=REC: raise RuntimeError('Zenodo draft DOI/record lock mismatch')
+
+          # Validate and persist metadata BEFORE touching inherited files.
+          metadata={
+            'upload_type':'dataset','publication_date':'2026-08-11','title':'Dr. Saeed Ghezelbash Public Knowledge Graph',
+            'creators':[{'name':'Ghezelbash, Saeed','orcid':'0009-0001-9346-8475'}],
+            'description':'<p>Immutable Version 1.1.0 preservation snapshot of the canonical first-party <strong>Dr. Saeed Ghezelbash Public Knowledge Graph</strong>. The primary entity and creator is Saeed Ghezelbash (Wikidata Q140287622); the Dataset authority entity is Q140304972 and the supporting clinic entity is Q140288589.</p><p>Canonical Dataset IRI: <a href="https://www.ghezelbaash.ir/graph.jsonld#dataset">https://www.ghezelbaash.ir/graph.jsonld#dataset</a>. Canonical live website: <a href="https://www.ghezelbaash.ir/">https://www.ghezelbaash.ir/</a>. Version-controlled source: <a href="https://github.com/medicaldoctor91/doctor-ghezelbaash">GitHub</a>. AI/ML-facing distribution: <a href="https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data">Hugging Face</a>.</p><p>This record preserves the exact frozen Version 1.1.0 core artifacts. Concept DOI identifies the continuing Dataset lineage; this record\'s Version DOI identifies this immutable snapshot.</p>',
+            'access_right':'open','license':'cc-by-4.0','version':'1.1.0',
+            'keywords':['Saeed Ghezelbash','Dr. Saeed Ghezelbash','knowledge graph','entity resolution','JSON-LD','RDF','Schema.org','Wikidata','FAIR data','machine-readable data','AI retrieval','RAG','Croissant','DCAT','Kermanshah','aesthetic medicine'],
+            'notes':f'Canonical Dataset IRI: https://www.ghezelbaash.ir/graph.jsonld#dataset. Zenodo Concept DOI: {CONCEPT}. Exact Version DOI: {VERSION}. Frozen source commit and artifact hashes are recorded in release-attestation.json and dist-sha256.json.',
+            'related_identifiers':[
+              {'identifier':'https://www.ghezelbaash.ir/graph.jsonld#dataset','relation':'isDerivedFrom','resource_type':'dataset'},
+              {'identifier':'https://github.com/medicaldoctor91/doctor-ghezelbaash','relation':'isDerivedFrom','resource_type':'software'},
+              {'identifier':'https://huggingface.co/datasets/doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data','relation':'isSourceOf','resource_type':'dataset'},
+              {'identifier':'https://www.wikidata.org/wiki/Q140304972','relation':'isPartOf','resource_type':'dataset'}
+            ],
+            'prereserve_doi':True
+          }
+          updated=call('PUT',f'{BASE}/deposit/depositions/{REC}',json.dumps({'metadata':metadata},ensure_ascii=False).encode(),{'Content-Type':'application/json'})
+          um=updated.get('metadata') or {}; upr=um.get('prereserve_doi') or {}
+          if um.get('upload_type')!='dataset' or um.get('version')!='1.1.0' or (um.get('creators') or [{}])[0].get('orcid')!='0009-0001-9346-8475': raise RuntimeError('Zenodo metadata readback mismatch')
+          if upr.get('doi')!=VERSION: raise RuntimeError('Zenodo DOI reservation changed during metadata update')
+          print('ZENODO_METADATA_VERIFICATION_PASS')
+
+          # Only after metadata validation, replace files on the unpublished new-version draft.
+          inherited=call('GET',f'{BASE}/deposit/depositions/{REC}/files')
+          for f in inherited:
+              fid=str(f.get('id') or '')
+              if not fid: raise RuntimeError('Inherited Zenodo file without id')
+              call('DELETE',f'{BASE}/deposit/depositions/{REC}/files/{fid}',ok=(204,))
+
+          boundary='----ghezelbaashZenodoFrozenBoundary7MA4YWxk'
+          def upload(name,path):
+              raw=path.read_bytes()
+              body=(f'--{boundary}\r\nContent-Disposition: form-data; name="name"\r\n\r\n{name}\r\n'.encode()+
+                    f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="{name}"\r\nContent-Type: application/octet-stream\r\n\r\n'.encode()+raw+b'\r\n'+
+                    f'--{boundary}--\r\n'.encode())
+              return call('POST',f'{BASE}/deposit/depositions/{REC}/files',body,{'Content-Type':f'multipart/form-data; boundary={boundary}'},ok=(201,))
+
+          local={}
+          for n in CORE: local[n]=FROZEN[n]; upload(n,DIST/n)
+          for n in EXTRA:
+              p=ROOT/n; local[n]=hashlib.sha256(p.read_bytes()).hexdigest(); upload(n,p)
+
+          remote=call('GET',f'{BASE}/deposit/depositions/{REC}/files')
+          names={f.get('filename') for f in remote}; expected=set(CORE+EXTRA)
+          if names!=expected: raise RuntimeError(f'Zenodo file inventory mismatch: {sorted(names)}')
+          for f in remote:
+              n=f['filename']; links=f.get('links') or {}; url=links.get('download')
+              if not url: raise RuntimeError(f'Zenodo download verification URL missing for {n}')
+              blob=call('GET',url,ok=(200,),binary=True)
+              if hashlib.sha256(blob).hexdigest()!=local[n]: raise RuntimeError(f'Zenodo remote SHA256 mismatch {n}')
+          print('ZENODO_DRAFT_REMOTE_BYTE_VERIFICATION_PASS')
+
+          published=call('POST',f'{BASE}/deposit/depositions/{REC}/actions/publish',ok=(200,201,202))
+          pubdoi=published.get('doi') or (published.get('metadata') or {}).get('doi') or VERSION
+          if pubdoi!=VERSION: raise RuntimeError(f'Published Version DOI mismatch: {pubdoi}')
+
+          public=None
+          for _ in range(45):
+              try:
+                  public=call('GET',f'{BASE}/records/{REC}',ok=(200,))
+                  if public.get('doi')==VERSION: break
+              except Exception: pass
+              time.sleep(2)
+          if not public or public.get('doi')!=VERSION: raise RuntimeError('Published Zenodo record did not become publicly resolvable')
+          pm=public.get('metadata') or {}
+          if pm.get('version')!='1.1.0' or pm.get('upload_type',{}).get('type') not in (None,'dataset') and pm.get('upload_type')!='dataset': raise RuntimeError('Public Zenodo metadata mismatch')
+          print(json.dumps({'stage':'ZENODO_PUBLISHED','recordId':REC,'conceptDoi':CONCEPT,'versionDoi':VERSION,'files':len(remote),'integrity':'PASS'},separators=(',',':')))
+          PY
+
+      - name: Report PASS
+        run: |
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'ZENODO_V1_1_PUBLISH_PASS
+          Release: 1.1.0
+          Concept DOI: 10.5281/zenodo.18765168
+          Version DOI: 10.5281/zenodo.21886743
+          Record ID: 21886743
+          Frozen Run ID: 31481133028
+          Zenodo: PUBLISHED / VERIFIED
+          Integrity: PASS'
+
+      - name: Report FAIL
+        if: failure()
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'ZENODO_V1_1_PUBLISH_V2_FAIL — downstream publication remains blocked.'

--- a/.github/workflows/run-final-ui-convergence-on-issue.yml
+++ b/.github/workflows/run-final-ui-convergence-on-issue.yml
@@ -1,0 +1,144 @@
+name: Run final 2026 UI convergence validation
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  converge:
+    if: github.event.issue.title == 'RUN-FINAL-UI-CONVERGENCE'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - name: Checkout isolated final UI branch
+        uses: actions/checkout@v4
+        with:
+          ref: final/ui-convergence
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup pinned Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+
+      - name: Apply deterministic UI convergence transform
+        run: node scripts/apply-final-ui-convergence.mjs
+
+      - name: Assert DOM/source placement contracts before generation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+          intro=Path('src/content-source/001-intro.html').read_text()
+          tail=Path('src/content-source/100-rc099.html').read_text()
+          assert intro.count('id="verified-physician-identity-core"')==1
+          assert intro.count('id="google-maps-clinic-reputation-current"')==1
+          assert intro.count('class="hero-search-launch"')==1
+          assert 'class="hero-trust-list"' not in intro
+          assert 'class="hero-reputation"' not in intro
+          assert 'class="hero-action hero-action--search"' not in intro
+          assert 'id="quick-start-title"' not in intro
+          assert tail.count('id="quick-start-title"')==1
+          assert tail.rstrip().endswith('</aside>')
+          subtitle=intro.index('<p class="hero-subtitle">')
+          search=intro.index('class="hero-search-launch"')
+          portrait=intro.index('class="hero-figure"')
+          assert subtitle < search < portrait
+          clinical=intro.index('دکتر سعید قزلباش در محیط بالینی')
+          verified=intro.index('id="verified-physician-identity-core"')
+          assert clinical < verified
+          for signal in ['جمعه تعطیل','Q140287622','0009-0001-9346-8475','/g/11nqdfk76c','۱۶۷۴۳۰','۱۶۴ نظر']:
+              assert signal in intro, signal
+          print('UI_SOURCE_PLACEMENT_PASS')
+          PY
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Regenerate deterministic source projections
+        run: npm run prepare:generated
+
+      - name: Run complete source/release audits
+        run: npm run release:prepare
+
+      - name: Build and validate ephemeral final candidate DIST
+        env:
+          ASTRO_TELEMETRY_DISABLED: '1'
+        run: npm run build
+
+      - name: Adversarially verify built HTML placement and preserved signals
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+          html=Path('dist/index.html').read_text()
+          assert html.count('id="verified-physician-identity-core"')==1
+          assert html.count('id="google-maps-clinic-reputation-current"')==1
+          assert html.count('class="hero-search-launch"')==1
+          assert 'class="hero-trust-list"' not in html
+          assert 'class="hero-reputation"' not in html
+          assert html.count('id="quick-start-title"')==1
+          # Search launcher is directly in the hero flow before the portrait.
+          s=html.index('class="hero-search-launch"'); p=html.index('class="hero-figure"')
+          assert s < p
+          # Verified identity is physically inside the second clinical image caption.
+          cap=html.index('class="clinical-figure-caption"'); ident=html.index('id="verified-physician-identity-core"',cap); cap_end=html.index('</figcaption>',cap)
+          assert cap < ident < cap_end
+          # Quick navigation has physically moved near the end of the canonical HTML body, not CSS-reordered.
+          q=html.index('id="quick-start-title"')
+          assert q > int(len(html)*0.90), (q,len(html))
+          for signal in ['جمعه تعطیل','Q140287622','0009-0001-9346-8475','/g/11nqdfk76c','10.5281/zenodo.21886743']:
+              assert signal in html, signal
+          print('UI_DIST_PLACEMENT_AND_SIGNAL_PASS')
+          PY
+
+      - name: Prove semantic graph identity did not change from parent freeze
+        shell: bash
+        run: |
+          set -euo pipefail
+          git show 24bf64f3975aa06d2e431261b0f0513759661900:src/data/semantic/knowledge-graph.jsonld > /tmp/parent-graph.jsonld
+          cmp --silent /tmp/parent-graph.jsonld src/data/semantic/knowledge-graph.jsonld || { echo 'Canonical semantic graph changed during presentation convergence' >&2; exit 72; }
+          echo 'SEMANTIC_GRAPH_IDENTITY_PRESERVED'
+
+      - name: Commit only validated source/presentation convergence
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'ghezelbaash-release-bot'
+          git config user.email 'actions@users.noreply.github.com'
+          git add src public
+          if git diff --cached --quiet; then
+            echo 'No UI source diff to commit' >&2
+            exit 74
+          fi
+          git commit -m 'Converge final 2026 hero UX without authority loss'
+          git push origin HEAD:final/ui-convergence
+
+      - name: Report PASS
+        shell: bash
+        run: |
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'FINAL_UI_CONVERGENCE_PASS
+          Branch: final/ui-convergence
+          Semantic graph identity vs frozen v1.1 source: PRESERVED
+          Search: compact bar under hero subtitle / functional trigger preserved
+          Trust + Google Maps: moved into hero caption / visible HTML preserved
+          Verified identity: moved into second image caption / canonical id + links preserved
+          Quick-start: physically moved to end of canonical content
+          Full release audits + ephemeral DIST validation: PASS
+          No downstream publication performed.'
+
+      - name: Report FAIL
+        if: failure()
+        shell: bash
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'FINAL_UI_CONVERGENCE_FAIL — candidate was not authorized for downstream publication. Existing frozen/Zenodo work remains untouched.'

--- a/.github/workflows/run-final-ui-convergence-on-issue.yml
+++ b/.github/workflows/run-final-ui-convergence-on-issue.yml
@@ -43,7 +43,7 @@ jobs:
           tail=Path('src/content-source/100-rc099.html').read_text()
           assert intro.count('id="verified-physician-identity-core"')==1
           assert intro.count('id="google-maps-clinic-reputation-current"')==1
-          assert intro.count('class="hero-search-launch"')==1
+          assert intro.count('class="hero-action hero-search-launch"')==1
           assert 'class="hero-trust-list"' not in intro
           assert 'class="hero-reputation"' not in intro
           assert 'class="hero-action hero-action--search"' not in intro
@@ -51,7 +51,7 @@ jobs:
           assert tail.count('id="quick-start-title"')==1
           assert tail.rstrip().endswith('</aside>')
           subtitle=intro.index('<p class="hero-subtitle">')
-          search=intro.index('class="hero-search-launch"')
+          search=intro.index('class="hero-action hero-search-launch"')
           portrait=intro.index('class="hero-figure"')
           assert subtitle < search < portrait
           clinical=intro.index('دکتر سعید قزلباش در محیط بالینی')
@@ -85,17 +85,14 @@ jobs:
           html=Path('dist/index.html').read_text()
           assert html.count('id="verified-physician-identity-core"')==1
           assert html.count('id="google-maps-clinic-reputation-current"')==1
-          assert html.count('class="hero-search-launch"')==1
+          assert html.count('class="hero-action hero-search-launch"')==1
           assert 'class="hero-trust-list"' not in html
           assert 'class="hero-reputation"' not in html
           assert html.count('id="quick-start-title"')==1
-          # Search launcher is directly in the hero flow before the portrait.
-          s=html.index('class="hero-search-launch"'); p=html.index('class="hero-figure"')
+          s=html.index('class="hero-action hero-search-launch"'); p=html.index('class="hero-figure"')
           assert s < p
-          # Verified identity is physically inside the second clinical image caption.
           cap=html.index('class="clinical-figure-caption"'); ident=html.index('id="verified-physician-identity-core"',cap); cap_end=html.index('</figcaption>',cap)
           assert cap < ident < cap_end
-          # Quick navigation has physically moved near the end of the canonical HTML body, not CSS-reordered.
           q=html.index('id="quick-start-title"')
           assert q > int(len(html)*0.90), (q,len(html))
           for signal in ['جمعه تعطیل','Q140287622','0009-0001-9346-8475','/g/11nqdfk76c','10.5281/zenodo.21886743']:

--- a/.github/workflows/run-v1-1-finalize-source-on-issue.yml
+++ b/.github/workflows/run-v1-1-finalize-source-on-issue.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Apply deterministic semantic source migration
         run: node scripts/finalize-release-source-v1.1.mjs
 
+      - name: Stamp release-aware entity media metadata
+        run: node scripts/stamp-release-media-v1.1.mjs
+
       - name: Validate release identity immediately after migration
         run: node scripts/validate-release-contract.mjs
 
@@ -57,7 +60,7 @@ jobs:
           set -euo pipefail
           git config user.name 'ghezelbaash-release-bot'
           git config user.email 'actions@users.noreply.github.com'
-          git add package.json package-lock.json src scripts
+          git add package.json package-lock.json src scripts public
           if git diff --cached --quiet; then
             echo 'NO_STAGE5_SOURCE_DIFF'
           else
@@ -70,3 +73,8 @@ jobs:
         run: |
           set -euo pipefail
           gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_FINALIZE_SOURCE_PASS\nRelease: 1.1.0\nConcept DOI: 10.5281/zenodo.18765168\nVersion DOI: 10.5281/zenodo.21886743\nRecord ID: 21886743\nCore frozen: false\nIntegrity: PASS'
+
+      - name: Report FAIL
+        if: failure()
+        shell: bash
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_FINALIZE_SOURCE_FAIL — inspect Actions job logs; no validated Stage 5 source commit was authorized.'

--- a/.github/workflows/run-v1-1-finalize-source-on-issue.yml
+++ b/.github/workflows/run-v1-1-finalize-source-on-issue.yml
@@ -1,0 +1,72 @@
+name: Run v1.1 semantic source finalization on issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  finalize-source:
+    if: github.event.issue.title == 'RUN-V1.1-FINALIZE-SOURCE'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - name: Checkout isolated release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release/v1.1.0-doi-gate
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Report start
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_FINALIZE_SOURCE_START'
+
+      - name: Setup pinned Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+
+      - name: Apply deterministic semantic source migration
+        run: node scripts/finalize-release-source-v1.1.mjs
+
+      - name: Validate release identity immediately after migration
+        run: node scripts/validate-release-contract.mjs
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Regenerate deterministic source projections
+        run: npm run prepare:generated
+
+      - name: Run full source release preparation and audits
+        run: npm run release:prepare
+
+      - name: Revalidate release contract after all source generators
+        run: node scripts/validate-release-contract.mjs
+
+      - name: Commit validated Stage 5 source state
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'ghezelbaash-release-bot'
+          git config user.email 'actions@users.noreply.github.com'
+          git add package.json package-lock.json src scripts
+          if git diff --cached --quiet; then
+            echo 'NO_STAGE5_SOURCE_DIFF'
+          else
+            git commit -m 'Finalize v1.1.0 semantic source after DOI lock [stage-5]'
+            git push origin HEAD:release/v1.1.0-doi-gate
+          fi
+
+      - name: Report PASS
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_FINALIZE_SOURCE_PASS\nRelease: 1.1.0\nConcept DOI: 10.5281/zenodo.18765168\nVersion DOI: 10.5281/zenodo.21886743\nRecord ID: 21886743\nCore frozen: false\nIntegrity: PASS'

--- a/.github/workflows/run-v1-1-finalize-source-v2-on-issue.yml
+++ b/.github/workflows/run-v1-1-finalize-source-v2-on-issue.yml
@@ -1,0 +1,59 @@
+name: Run v1.1 Stage 5 fail-closed finalization v2
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  finalize:
+    if: github.event.issue.title == 'RUN-V1.1-FINALIZE-SOURCE-V2'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/v1.1.0-doi-gate
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+      - name: Execute Stage 5 with fail-closed diagnostics
+        shell: bash
+        run: |
+          set +e
+          : > /tmp/stage5.log
+          run_cmd(){ echo "===== $* =====" >>/tmp/stage5.log; "$@" >>/tmp/stage5.log 2>&1; return $?; }
+          run_cmd node scripts/finalize-release-source-v1.1.mjs; RC=$?
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/stamp-release-media-v1.1.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/validate-release-contract.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm ci; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm run prepare:generated; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/lock-release-rdf-invariants-v1.1.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm run release:prepare; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/validate-release-contract.mjs; RC=$?; fi
+          if [ "$RC" -ne 0 ]; then
+            python - <<'PY' >/tmp/body.txt
+          from pathlib import Path
+          t=Path('/tmp/stage5.log').read_text(errors='replace')[-12000:]
+          print('V1_1_STAGE5_FAIL\n```text\n'+t.replace('```','` ` `')+'\n```\nNo validated Stage 5 commit was authorized.')
+          PY
+            gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt
+            exit "$RC"
+          fi
+          git config user.name 'ghezelbaash-release-bot'
+          git config user.email 'actions@users.noreply.github.com'
+          git add package.json package-lock.json src scripts public
+          if ! git diff --cached --quiet; then
+            git commit -m 'Finalize v1.1.0 semantic source after DOI lock [stage-5]'
+            git push origin HEAD:release/v1.1.0-doi-gate
+          fi
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_STAGE5_PASS\nRelease: 1.1.0\nConcept DOI: 10.5281/zenodo.18765168\nVersion DOI: 10.5281/zenodo.21886743\nRecord ID: 21886743\nCore: NOT BUILT / NOT FROZEN\nIntegrity: PASS'

--- a/.github/workflows/run-v1-1-finalize-source-v3-on-issue.yml
+++ b/.github/workflows/run-v1-1-finalize-source-v3-on-issue.yml
@@ -1,0 +1,60 @@
+name: Run v1.1 Stage 5 fail-closed finalization v3
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  finalize:
+    if: github.event.issue.title == 'RUN-V1.1-FINALIZE-SOURCE-V3'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/v1.1.0-doi-gate
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+      - name: Execute Stage 5 with fail-closed diagnostics
+        shell: bash
+        run: |
+          set +e
+          : > /tmp/stage5.log
+          run_cmd(){ echo "===== $* =====" >>/tmp/stage5.log; "$@" >>/tmp/stage5.log 2>&1; return $?; }
+          run_cmd node scripts/finalize-release-source-v1.1.mjs; RC=$?
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/finalize-release-support-nodes-v1.1.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/stamp-release-media-v1.1.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/validate-release-contract.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm ci; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm run prepare:generated; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/lock-release-rdf-invariants-v1.1.mjs; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd npm run release:prepare; RC=$?; fi
+          if [ "$RC" -eq 0 ]; then run_cmd node scripts/validate-release-contract.mjs; RC=$?; fi
+          if [ "$RC" -ne 0 ]; then
+            python - <<'PY' >/tmp/body.txt
+          from pathlib import Path
+          t=Path('/tmp/stage5.log').read_text(errors='replace')[-14000:]
+          print('V1_1_STAGE5_FAIL\n```text\n'+t.replace('```','` ` `')+'\n```\nNo validated Stage 5 commit was authorized.')
+          PY
+            gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file /tmp/body.txt
+            exit "$RC"
+          fi
+          git config user.name 'ghezelbaash-release-bot'
+          git config user.email 'actions@users.noreply.github.com'
+          git add package.json package-lock.json src scripts public
+          if ! git diff --cached --quiet; then
+            git commit -m 'Finalize v1.1.0 semantic source after DOI lock [stage-5]'
+            git push origin HEAD:release/v1.1.0-doi-gate
+          fi
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_STAGE5_PASS\nRelease: 1.1.0\nConcept DOI: 10.5281/zenodo.18765168\nVersion DOI: 10.5281/zenodo.21886743\nRecord ID: 21886743\nCore: NOT BUILT / NOT FROZEN\nIntegrity: PASS'

--- a/.github/workflows/run-v1-1-freeze-dist-on-issue.yml
+++ b/.github/workflows/run-v1-1-freeze-dist-on-issue.yml
@@ -1,0 +1,128 @@
+name: Run v1.1 FINAL DIST one-shot freeze
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+  actions: read
+
+jobs:
+  freeze:
+    if: github.event.issue.title == 'RUN-V1.1-FREEZE-DIST'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/v1.1.0-doi-gate
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+      - name: Enforce one-shot freeze gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          test ! -f .release/freeze.json || { echo 'Frozen release already exists; regeneration forbidden.' >&2; exit 73; }
+          node scripts/validate-release-contract.mjs
+          git diff --exit-code
+      - name: Install locked dependencies
+        run: npm ci
+      - name: Build FINAL DIST exactly once
+        run: npm run build
+      - name: Prove build did not mutate committed source
+        run: git diff --exit-code
+      - name: Create detached release attestation and exhaustive dist hashes
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/frozen-v1.1.0
+          cp -a dist /tmp/frozen-v1.1.0/dist
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
+          SOURCE_COMMIT="$SOURCE_COMMIT" python - <<'PY'
+          import hashlib,json,os
+          from pathlib import Path
+          root=Path('/tmp/frozen-v1.1.0/dist')
+          required=['graph.jsonld','graph.ttl','entity-facts.csv','answers.txt','knowledge.xml','llms.txt','llms-full.txt','index.md','datapackage.json','croissant.json','dcat.ttl','void.ttl','linkset.json','provenance.jsonld','evidence-snapshot.json','shapes.ttl','artifact-manifest.json']
+          for f in required:
+              if not (root/f).is_file(): raise SystemExit(f'Missing frozen core artifact: {f}')
+          hashes={}
+          for p in sorted(x for x in root.rglob('*') if x.is_file()):
+              hashes[p.relative_to(root).as_posix()]=hashlib.sha256(p.read_bytes()).hexdigest()
+          Path('/tmp/frozen-v1.1.0/dist-sha256.json').write_text(json.dumps(hashes,sort_keys=True,indent=2)+'\n')
+          manifest_sha=hashes['artifact-manifest.json']
+          att={
+            'release':'1.1.0','sourceCommit':os.environ['SOURCE_COMMIT'],
+            'canonicalDatasetIri':'https://www.ghezelbaash.ir/graph.jsonld#dataset',
+            'primaryEntity':'Q140287622','datasetEntity':'Q140304972','clinicEntity':'Q140288589',
+            'zenodoConceptDoi':'10.5281/zenodo.18765168','zenodoVersionDoi':'10.5281/zenodo.21886743','zenodoRecordId':'21886743',
+            'artifactManifestSha256':manifest_sha,'distFileCount':len(hashes),'validation':'PASS','coreFrozen':True
+          }
+          Path('/tmp/frozen-v1.1.0/release-attestation.json').write_text(json.dumps(att,sort_keys=True,indent=2)+'\n')
+          print(json.dumps(att,separators=(',',':')))
+          PY
+      - name: Upload immutable frozen release payload
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: dr-saeed-ghezelbash-v1.1.0-frozen-release
+          path: /tmp/frozen-v1.1.0
+          include-hidden-files: true
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 90
+      - name: Lock freeze locator on release branch
+        shell: bash
+        env:
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p .release
+          SOURCE_COMMIT="$(git rev-parse HEAD)"
+          SOURCE_COMMIT="$SOURCE_COMMIT" python - <<'PY'
+          import json,os
+          from pathlib import Path
+          att=json.loads(Path('/tmp/frozen-v1.1.0/release-attestation.json').read_text())
+          freeze={
+            'stage':'HASH_FREEZE','release':'1.1.0','coreFrozen':True,'integrity':'PASS',
+            'sourceCommit':os.environ['SOURCE_COMMIT'],'githubRunId':os.environ['GITHUB_RUN_ID'],
+            'artifactName':'dr-saeed-ghezelbash-v1.1.0-frozen-release',
+            'artifactId':os.environ.get('ARTIFACT_ID',''),'artifactDigest':os.environ.get('ARTIFACT_DIGEST',''),
+            'artifactManifestSha256':att['artifactManifestSha256'],
+            'conceptDoi':'10.5281/zenodo.18765168','versionDoi':'10.5281/zenodo.21886743','zenodoRecordId':'21886743'
+          }
+          Path('.release/freeze.json').write_text(json.dumps(freeze,sort_keys=True,indent=2)+'\n')
+          Path('.release/release-attestation.json').write_text(json.dumps(att,sort_keys=True,indent=2)+'\n')
+          PY
+          git config user.name 'ghezelbaash-release-bot'
+          git config user.email 'actions@users.noreply.github.com'
+          git add .release/freeze.json .release/release-attestation.json
+          git commit -m 'Freeze immutable v1.1.0 FINAL DIST [stage-8]'
+          git push origin HEAD:release/v1.1.0-doi-gate
+      - name: Report freeze PASS
+        shell: bash
+        env:
+          ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+        run: |
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "V1_1_FREEZE_PASS
+          Release: 1.1.0
+          Concept DOI: 10.5281/zenodo.18765168
+          Version DOI: 10.5281/zenodo.21886743
+          Record ID: 21886743
+          GitHub Run ID: $GITHUB_RUN_ID
+          Artifact: dr-saeed-ghezelbash-v1.1.0-frozen-release
+          Artifact digest: $ARTIFACT_DIGEST
+          Core: FROZEN
+          Integrity: PASS"
+      - name: Report freeze FAIL
+        if: failure()
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_FREEZE_FAIL — no valid freeze locator was authorized; do not proceed to Zenodo upload.'

--- a/.github/workflows/run-v1-1-revalidate-source-v4-on-issue.yml
+++ b/.github/workflows/run-v1-1-revalidate-source-v4-on-issue.yml
@@ -1,0 +1,59 @@
+name: Revalidate v1.1 source after release-node convergence
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  revalidate:
+    if: github.event.issue.title == 'RUN-V1.1-REVALIDATE-SOURCE-V4'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ISSUE: ${{ github.event.issue.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/v1.1.0-doi-gate
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+      - name: Converge current release-scoped graph nodes
+        run: node scripts/finalize-release-support-nodes-v1.1.mjs
+      - name: Stamp release-aware entity media metadata
+        run: node scripts/stamp-release-media-v1.1.mjs
+      - name: Validate locked release identity
+        run: node scripts/validate-release-contract.mjs
+      - name: Install locked dependencies
+        run: npm ci
+      - name: Regenerate deterministic source projections
+        run: npm run prepare:generated
+      - name: Lock RDF release invariant from deterministic output
+        run: node scripts/lock-release-rdf-invariants-v1.1.mjs
+      - name: Run complete Stage 5 audits
+        run: npm run release:prepare
+      - name: Revalidate locked release identity after generators
+        run: node scripts/validate-release-contract.mjs
+      - name: Commit only fully validated source convergence
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'ghezelbaash-release-bot'
+          git config user.email 'actions@users.noreply.github.com'
+          git add package.json package-lock.json src scripts public
+          if ! git diff --cached --quiet; then
+            git commit -m 'Converge all v1.1.0 release-scoped graph nodes [stage-5]'
+            git push origin HEAD:release/v1.1.0-doi-gate
+          fi
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_STAGE5_REVALIDATION_PASS\nRelease: 1.1.0\nConcept DOI: 10.5281/zenodo.18765168\nVersion DOI: 10.5281/zenodo.21886743\nRecord ID: 21886743\nCore: NOT FROZEN\nIntegrity: PASS'
+      - name: Report FAIL
+        if: failure()
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'V1_1_STAGE5_REVALIDATION_FAIL — no downstream release action authorized.'

--- a/.github/workflows/run-zenodo-v1-1-doi-gate-on-issue.yml
+++ b/.github/workflows/run-zenodo-v1-1-doi-gate-on-issue.yml
@@ -1,0 +1,90 @@
+name: Run Zenodo v1.1 DOI gate on issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  lock-doi:
+    if: github.event.issue.title == 'RUN-ZENODO-V1.1-DOI-GATE'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN || secrets.ZENODO_ACCESS_TOKEN || secrets.ZENODO_API_TOKEN }}
+    steps:
+      - name: Checkout isolated release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release/v1.1.0-doi-gate
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Report start
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'ZENODO_V1_1_DOI_GATE_START'
+        env:
+          ISSUE: ${{ github.event.issue.number }}
+
+      - name: Verify secure Zenodo credential
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${ZENODO_TOKEN:-}" ]; then
+            gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body 'ZENODO_V1_1_DOI_GATE_FAIL: no supported Zenodo secret name resolved; no Zenodo mutation performed.'
+            exit 78
+          fi
+          echo 'ZENODO_CREDENTIAL_AVAILABLE'
+        env:
+          ISSUE: ${{ github.event.issue.number }}
+
+      - name: Create/reuse draft and lock authoritative identifiers
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/zenodo-doi-gate.py
+
+      - name: Validate and commit lock to release branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          s=json.loads(Path('.release/doi-gate.json').read_text())
+          r=json.loads(Path('src/data/release.json').read_text())
+          z=r['dataset']['zenodo']
+          assert s['integrity']=='PASS'
+          assert r['release']=='1.1.0'
+          assert z['conceptDoi']==s['conceptDoi']
+          assert z['versionDoi']==s['versionDoi']
+          assert str(z['recordId'])==str(s['recordId'])
+          assert z['state']=='doi-locked-draft'
+          assert s['coreFrozen'] is False
+          print('DOI_GATE_VALIDATION_PASS')
+          PY
+          git config user.name 'ghezelbaash-release-bot'
+          git config user.email 'actions@users.noreply.github.com'
+          git add src/data/release.json .release/doi-gate.json
+          if ! git diff --cached --quiet; then
+            git commit -m 'Lock Zenodo v1.1.0 DOI gate [zenodo-doi-lock]'
+            git push origin HEAD:release/v1.1.0-doi-gate
+          fi
+
+      - name: Report verified non-secret identifiers
+        shell: bash
+        run: |
+          set -euo pipefail
+          BODY="$(python - <<'PY'
+          import json
+          from pathlib import Path
+          s=json.loads(Path('.release/doi-gate.json').read_text())
+          print('ZENODO_V1_1_DOI_GATE_PASS\\nConcept DOI: '+s['conceptDoi']+'\\nVersion DOI: '+s['versionDoi']+'\\nRecord ID: '+str(s['recordId'])+'\\nCore frozen: false\\nIntegrity: PASS')
+          PY
+          )"
+          gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+        env:
+          ISSUE: ${{ github.event.issue.number }}


### PR DESCRIPTION
Merge main-only operational workflows into final/release-convergence before final promotion. Compare shows the main-only side contains only added audit/runner workflow files and no source/content/semantic changes. This preserves all prior work without changing the frozen release artifact.