### PR TITLE
Fix canonical Cloudflare cache purge capability

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -23,6 +23,7 @@ jobs:
       CF_PRODUCTION_BRANCH: production/deploy
       CF_PREVIEW_BRANCH: staging/deploy
       ZONE_NAME: ghezelbaash.ir
+      CANONICAL_HOST: www.ghezelbaash.ir
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -68,13 +69,15 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/verify-cloudflare-pages-deployment.mjs
-      - name: Purge production edge cache after native Git deployment
+      - name: Purge production edge cache with ephemeral least-privilege token
         if: github.ref == 'refs/heads/production/deploy'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -euo pipefail
-          node scripts/purge-cloudflare-current.mjs
+          python scripts/configure-cloudflare-edge.py \
+            --purge-cache-only \
+            --outcome edge-cache-purge.json
       - name: Verify production bytes, current serving, and T+0 discovery freshness
         if: github.ref == 'refs/heads/production/deploy'
         env:

--- a/scripts/purge-cloudflare-current.mjs
+++ b/scripts/purge-cloudflare-current.mjs
@@ -1,8 +1,0 @@
-const token=process.env.CLOUDFLARE_API_TOKEN||'',account=process.env.CLOUDFLARE_ACCOUNT_ID||'',zoneName=process.env.ZONE_NAME||'ghezelbaash.ir';
-if(!token||!account)throw new Error('Cloudflare purge credentials missing');
-const headers={authorization:`Bearer ${token}`,'content-type':'application/json'};
-const listing=await fetch(`https://api.cloudflare.com/client/v4/zones?name=${encodeURIComponent(zoneName)}&account.id=${encodeURIComponent(account)}`,{headers,signal:AbortSignal.timeout(30000)});const lj=await listing.json();
-if(!listing.ok||!lj.success||lj.result?.length!==1)throw new Error(`Cloudflare zone lookup failed ${listing.status}`);
-const zone=lj.result[0].id;const purge=await fetch(`https://api.cloudflare.com/client/v4/zones/${zone}/purge_cache`,{method:'POST',headers,body:JSON.stringify({purge_everything:true}),signal:AbortSignal.timeout(30000)});const pj=await purge.json();
-if(!purge.ok||!pj.success)throw new Error(`Cloudflare purge failed ${purge.status}: ${JSON.stringify(pj.errors||[])}`);
-console.log(JSON.stringify({cloudflarePurge:'PASS',zone:zoneName,zoneId:zone}));


### PR DESCRIPTION
Website/control-plane fix only, based on the latest stable main.

- route production cache purge through the existing canonical Cloudflare reconciler
- use the already-proven short-lived child token limited to Zone Read + Cache Purge, revoked in the same transaction
- remove the parallel direct-purge JavaScript implementation
- keep deployment identity, branch isolation, byte verification, and T+0/T+2m/T+5m freshness gates unchanged

No visible content, semantic graph, retrieval corpus, release identity, DOI, or unrelated external-data workflows are modified.