### PR TITLE
Polish final source contracts without DIST changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is the version-controlled **source and generation authority**. T
 
 ## Canonical source
 
-- Page content: `src/content-source/`
+- Page content: `src/content-source/page.md`
 - Knowledge graph: `src/data/semantic/knowledge-graph.jsonld`
 - Release/entity truth: `src/data/release.json`, `src/data/release-invariants.json`
 - Evidence/freshness inputs: `src/data/evidence-registry.json`, `src/data/evidence-snapshot.json`, `src/data/volatile-facts.json`
@@ -56,4 +56,4 @@ Runtime target: Node 24.18.0 / npm 11.x. Deployment target: Cloudflare Pages sta
 - Hugging Face: `doctor-ghezelbaash/dr-saeid-ghezelbaash-entity-data`
 - Wikidata: physician `Q140287622`, clinic `Q140288589`, Dataset `Q140304972`
 
-The atomic ceiling-release workflow reserves the next DOI, promotes all source contracts, builds once, publishes the same Core bytes to the live site, Zenodo and Hugging Face, preserves the governed aggressive Hugging Face enrichment layer, and runs three verification rounds before it publishes the source commit and version tag.
+The normal website build is deterministic and does not reserve DOI records or publish external distributions. Release-only promotion, packaging, Zenodo preservation and Hugging Face publication are explicit operations outside the routine build path; each consumes the same canonical release/entity truth and is followed by convergence verification before a release is considered complete.

--- a/scripts/lib/assemble-content.mjs
+++ b/scripts/lib/assemble-content.mjs
@@ -42,5 +42,5 @@ export async function assembleCanonicalContent({root=process.cwd()}={}){
   let content=await readFile(path.join(root,'src/content-source/page.md'),'utf8');
   content=bindReleaseTokens(content,release);
   content=await bindLiveReputation(root,content,release);
-  return {content,names,inserted:0,fullInserted:0,deduplicatedExecutive:0,deduplicatedFull:0};
+  return {content,names};
 }


### PR DESCRIPTION
Final zero-output-delta source polish after the canonical architecture refactor.

Changes:
- align README with the actual current build/release control plane
- point canonical page documentation to the exact `src/content-source/page.md`
- remove obsolete zero-valued assembler return fields left from the retired answer injection/deduplication phase

Non-goals:
- no content changes
- no machine endpoint changes
- no header/Cloudflare changes
- no semantic/retrieval strength changes

Required gate: normal CI/build must pass with unchanged DIST behavior.