### PR TITLE
Bind Hugging Face verifier modes correctly

### DIFF
--- a/.github/workflows/hf-profile-surfaces.yml
+++ b/.github/workflows/hf-profile-surfaces.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           node-version: 24.18.0
       - name: Verify physician-first Hugging Face authority topology without mutation
-        run: node scripts/verify-huggingface-authority.mjs
+        run: node scripts/verify-huggingface-authority.mjs --profile

--- a/.github/workflows/hf-viewer-guard.yml
+++ b/.github/workflows/hf-viewer-guard.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           node-version: 24.18.0
       - name: Verify authority surfaces and Dataset Server configs
-        run: node scripts/verify-huggingface-authority.mjs
+        run: node scripts/verify-huggingface-authority.mjs --viewer


### PR DESCRIPTION
Narrow wiring fix only: viewer guard invokes --viewer and profile verifier invokes --profile. No source payload, semantic data, build, or deployment policy changes.