### PR TITLE
Harden delayed Cloudflare discovery convergence

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -72,7 +72,7 @@ jobs:
           python scripts/configure-cloudflare-edge.py \
             --purge-cache-only \
             --outcome edge-cache-purge.json
-      - name: Verify production bytes, current serving, and T+0 discovery freshness
+      - name: Verify exact production serving and sample T+0 discovery
         env:
           CANDIDATE_SHA: ${{ github.sha }}
         run: |
@@ -80,11 +80,21 @@ jobs:
           node scripts/verify-cloudflare-pages-deployment.mjs
           npm run verify:production
           node scripts/verify-current-serving.mjs
-          npm run verify:public-discovery
-      - name: Reverify ordinary and cache-busted discovery at T+2m and T+5m
+          if npm run verify:public-discovery; then
+            echo 'PUBLIC_DISCOVERY_T0_PASS'
+          else
+            echo '::warning::T+0 public discovery sampled a stale Cloudflare PoP after exact production bytes were already proven; delayed convergence gates will decide final success.'
+          fi
+      - name: Require public discovery convergence by T+5m
         run: |
           set -euo pipefail
           sleep 120
-          npm run verify:public-discovery
+          if npm run verify:public-discovery; then
+            echo 'PUBLIC_DISCOVERY_T2_PASS'
+          else
+            echo '::warning::T+2 public discovery still sampled distributed edge drift; T+5 remains the hard convergence gate.'
+          fi
           sleep 180
           npm run verify:public-discovery
+          node scripts/verify-current-serving.mjs
+          echo 'PUBLIC_DISCOVERY_T5_HARD_PASS'

--- a/.github/workflows/reputation-refresh.yml
+++ b/.github/workflows/reputation-refresh.yml
@@ -125,7 +125,7 @@ jobs:
           done
           echo '::error::Hugging Face current observation did not converge after reconciliation'
           exit 1
-      - name: Prove ordinary edge convergence after authority synchronization
+      - name: Prove edge and cross-surface convergence after authority synchronization
         if: steps.places.outputs.changed == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -135,15 +135,25 @@ jobs:
         run: |
           set -euo pipefail
           if ! node scripts/verify-cloudflare-pages-deployment.mjs; then
-            echo '::warning::Fresh origin is exact but ordinary edge is stale; purging once more before final convergence proof.'
+            echo '::warning::Fresh origin is exact but ordinary edge is stale; purging once more before delayed convergence checks.'
             python scripts/configure-cloudflare-edge.py --purge-cache-only
             sleep 90
             node scripts/verify-cloudflare-pages-deployment.mjs
           fi
           npm run verify:production
           node scripts/verify-current-serving.mjs --website-only
-          node scripts/verify-public-discovery-freshness.mjs
+          if node scripts/verify-public-discovery-freshness.mjs; then
+            echo 'REPUTATION_PUBLIC_DISCOVERY_T0_PASS'
+          else
+            echo '::warning::T+0 discovery sampled a stale Cloudflare PoP; exact website serving and HF authority are already proven, so delayed convergence remains authoritative.'
+          fi
           sleep 120
+          if node scripts/verify-public-discovery-freshness.mjs; then
+            echo 'REPUTATION_PUBLIC_DISCOVERY_T2_PASS'
+          else
+            echo '::warning::T+2 discovery still sampled distributed edge drift; final delayed gate remains mandatory.'
+          fi
+          sleep 180
           node scripts/verify-public-discovery-freshness.mjs
           node scripts/verify-current-serving.mjs
-          echo 'REPUTATION_CROSS_SURFACE_CONVERGENCE_PASS'
+          echo 'REPUTATION_CROSS_SURFACE_T5_HARD_PASS'


### PR DESCRIPTION
Keep exact deployment/current-serving as immediate hard gates, but treat T+0/T+2 multi-PoP public discovery drift as diagnostic and make T+5 the final hard convergence gate. Applies the same semantics to reputation publication. No source payload or SEO/entity changes.