### PR TITLE
Harden source integrity validation

### DIFF
--- a/scripts/validate-repository-hygiene.mjs
+++ b/scripts/validate-repository-hygiene.mjs
@@ -33,13 +33,17 @@ const styles=tracked.filter(name=>name.startsWith('src/styles/'));
 const allowedStyles=['src/styles/critical-mobile.css','src/styles/global.css'];
 if(styles.length!==allowedStyles.length||styles.some((name,index)=>name!==allowedStyles[index]))throw new Error(`Stylesheet topology drift: ${styles.join(', ')}`);
 
+const forbiddenControlByte=byte=>(byte<=0x08)||(byte>=0x0b&&byte<=0x0c)||(byte>=0x0e&&byte<=0x1f)||byte===0x7f;
 for(const name of tracked){
-  if(name==='scripts/validate-repository-hygiene.mjs')continue;
   const ext=path.posix.extname(name).toLowerCase();
   if(!textExtensions.has(ext)&&!textExactNames.has(path.posix.basename(name)))continue;
-  const content=await readFile(path.join(root,name),'utf8');
+  const raw=await readFile(path.join(root,name));
+  const controlOffset=raw.findIndex(forbiddenControlByte);
+  if(controlOffset!==-1)throw new Error(`Forbidden ASCII control byte 0x${raw[controlOffset].toString(16).padStart(2,'0')} in tracked text source: ${name} at byte ${controlOffset}`);
+  if(name==='scripts/validate-repository-hygiene.mjs')continue;
+  const content=raw.toString('utf8');
   if(devMarker.test(content))throw new Error(`Development marker leaked into tracked source: ${name}`);
   devMarker.lastIndex=0;
 }
 
-console.log(JSON.stringify({repositoryHygiene:'PASS',trackedFiles:tracked.length,canonicalContent:'src/content-source/page.md',styles:allowedStyles,generatedRuntimeTracked:false,temporaryOrBackupFilesTracked:false,oneShotMaintenanceWorkflowsTracked:false,runtimeSourceWrappersTracked:false,developmentMarkers:false},null,2));
+console.log(JSON.stringify({repositoryHygiene:'PASS',trackedFiles:tracked.length,canonicalContent:'src/content-source/page.md',styles:allowedStyles,generatedRuntimeTracked:false,temporaryOrBackupFilesTracked:false,oneShotMaintenanceWorkflowsTracked:false,runtimeSourceWrappersTracked:false,developmentMarkers:false,forbiddenAsciiControlBytes:false},null,2));

--- a/scripts/validate-source.mjs
+++ b/scripts/validate-source.mjs
@@ -10,14 +10,14 @@ const scriptSteps=name=>String(pkg.scripts?.[name]||'').split('&&').map(x=>x.tri
 if(pkg.scripts?.['validate:release-contract']!=='node scripts/validate-release-contract.mjs')fail('Generic release-contract validator wiring missing');
 if(!hasStep('prepare:generated','validate:media-references')||!hasStep('prepare:generated','rdf:generate')||!hasStep('prepare:generated','npm run generate'))fail('Generated preparation architecture drift');
 if(pkg.scripts?.['validate:media-references']!=='node scripts/validate-media-references.mjs')fail('Read-only media reference validator wiring missing');
-if(/writeFile|appendFile/.test(mediaReferenceValidator))fail('Media reference validation must never rewrite source');
+if(/\bwriteFile\b|\bappendFile\b/.test(mediaReferenceValidator))fail('Media reference validation must never rewrite source');
 const generateSteps=scriptSteps('generate');for(const expected of ['node scripts/generate-projections.mjs','node scripts/generate-retrieval-projections.mjs','node scripts/generate-descriptors.mjs'])if(!generateSteps.includes(expected))fail(`Canonical generator missing ${expected}`);if(generateSteps.indexOf('node scripts/generate-projections.mjs')>generateSteps.indexOf('node scripts/generate-retrieval-projections.mjs')||generateSteps.indexOf('node scripts/generate-retrieval-projections.mjs')>generateSteps.indexOf('node scripts/generate-descriptors.mjs'))fail('Canonical generator order drift');
 if(pkg.scripts?.['descriptors:finalize']!=='node scripts/generate-descriptors.mjs --dist dist')fail('DIST descriptor finalization stage missing');
 for(const required of ['astro build','npm run indexnow:prepare','npm run descriptors:finalize','node scripts/finalize-dist.mjs'])if(!hasStep('build',required))fail(`Build DAG missing ${required}`);
 if(retrievalGenerator.includes('public/current-release-matrix.json'))fail('Current release matrix has multiple deployable writers');
-if(/service_id\s*:|service_family\s*:/.test(retrievalGenerator))fail('Query Matrix legacy scalar service schema remains in generator');
+if(/\bservice_id\s*:|\bservice_family\s*:/.test(retrievalGenerator))fail('Query Matrix legacy scalar service schema remains in generator');
 if(!finalizer.includes("projections/current-release-matrix.json")||!finalizer.includes('writeFile(currentMatrixPath'))fail('Finalizer is not the sole current-release-matrix DIST composer');
-if(/mutateRoute|setDigest/.test(finalizer))fail('Finalizer still carries post-definition header policy patching');
+if(/\bmutateRoute\b|\bsetDigest\b/.test(finalizer))fail('Finalizer still carries post-definition header policy patching');
 if(documentHead.includes("replace(viewportTag")||documentHead.includes("replace(heroPreloadTag"))fail('DocumentHead still reorders the canonical Head template');
 if(!baseLayout.includes("../lib/css-delivery.mjs")||!baseGenerator.includes("../src/lib/css-delivery.mjs"))fail('CSS delivery contract is not shared by Layout and generator');
 for(const name of ['datapackage.json','croissant.json','dcat.ttl','void.ttl','linkset.json']){if(baseGenerator.includes(`writeFile(path.join(projections,'${name}')`))fail(`Base generator illegally writes descriptor ${name}`);if(finalizer.includes(`writeFile(path.join(dist,'${name}')`))fail(`Finalizer illegally rewrites descriptor ${name}`);if(!descriptorGenerator.includes(`writeFile(out('${name}')`))fail(`Descriptor generator missing canonical writer for ${name}`)}


### PR DESCRIPTION
Fix accidental ASCII Backspace bytes in validator regex boundaries and add repository-hygiene enforcement that rejects forbidden C0/DEL control bytes in tracked text sources. This keeps the canonical validator semantics explicit and prevents recurrence in future source archives.