### PR TITLE
Capture production baseline DIST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
             done
             exit "$rc"
           fi
+      - name: Upload baseline DIST candidate
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: baseline-dist-${{ github.sha }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 7
       - name: Package canonical source backup
         if: github.ref == 'refs/heads/main'
         run: npm run package:source


### PR DESCRIPTION
Comparison-only PR used to capture the exact production baseline DIST from commit ac9405f7. Baseline artifact was compared against the modernization candidate; page output was byte-identical. This PR is intentionally closed without merge.