### PR TITLE
Test Astro 7.2.2 for measurable benefit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
         with:
           python-version: '3.14.6'
-      - run: npm ci --ignore-scripts
+      - name: Resolve candidate lockfile without mutating source
+        run: |
+          npm install --ignore-scripts --package-lock-only
+          npm ci --ignore-scripts
       - name: Release preparation diagnostics
         shell: bash
         run: |
@@ -51,6 +54,22 @@ jobs:
             done
             exit "$rc"
           fi
+      - name: Upload candidate lockfile
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: astro-7-2-2-lock-${{ github.sha }}
+          path: package-lock.json
+          if-no-files-found: error
+          retention-days: 7
+      - name: Upload candidate DIST
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: astro-7-2-2-dist-${{ github.sha }}
+          path: dist
+          if-no-files-found: error
+          retention-days: 7
       - name: Package canonical source backup
         if: github.ref == 'refs/heads/main'
         run: npm run package:source

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@astrojs/check": "0.9.10",
     "@types/node": "24.13.3",
-    "astro": "7.1.6",
+    "astro": "7.2.2",
     "exiftool-vendored": "37.1.0",
     "jsonld": "9.0.0",
     "parse5": "8.0.1",


### PR DESCRIPTION
Superseded by PR #261. Astro 7.2.2 was retested in the combined core modernization and merged only after canonical npm ci, release:prepare, production build, and DIST equivalence checks passed.