### PR TITLE
Temporary canonical source backup extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,8 @@ jobs:
             exit "$rc"
           fi
       - name: Package canonical source backup
-        if: github.ref == 'refs/heads/main'
         run: npm run package:source
       - name: Upload canonical source backup
-        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: doctor-ghezelbaash-source-${{ github.sha }}


### PR DESCRIPTION
Temporary packaging PR completed successfully and was intentionally closed without merge. Full canonical npm ci, release:prepare, production build, package:source, and artifact upload all passed. The temporary branch differed from canonical main only by deleting the two main-only conditions around source packaging. For the delivered backup, .github/workflows/ci.yml was restored to canonical main blob dd3adfc47801f42cb9403eb4238197bdea2d4161 before deterministic repackaging. Final backup inventory: 244 tracked files; 32,463,212 uncompressed bytes; 27,563,531 archive bytes; SHA-256 171be1e3087de8381b7e73841573578593397cb204de32efd457d8058cf77570. The temporary branch was reset back to canonical main after extraction. Canonical source baseline is main commit fcab8a2615feadec3bebf57449a2e8c3c119ab5b, which contains zero file changes relative to 43eb0f0512a18e9ae67c08dc8df4b21db3edfce2.