### PR TITLE
Temporary named-as repair retry Q140288589

### DIFF
--- a/tmp-fix-named-as-pr2-trigger.txt
+++ b/tmp-fix-named-as-pr2-trigger.txt
@@ -1,0 +1,1 @@
+temporary trigger only


### PR DESCRIPTION
Temporary same-repository draft PR used only to execute the guarded P1810/P1932 repair after a transient Wikidata maxlag response. It will not be merged.