### PR TITLE
Temporary read-only Wikimedia integrity audit

### DIFF
--- a/tmp-readonly-wikimedia-integrity-trigger.txt
+++ b/tmp-readonly-wikimedia-integrity-trigger.txt
@@ -1,0 +1,1 @@
+temporary trigger only


### PR DESCRIPTION
Temporary draft PR used only to run a read-only live audit of the three Wikidata entities and related Wikimedia pages. No Wikidata/Wikipedia/Wikisource/Wikiversity edits are performed. It will not be merged.